### PR TITLE
Update modis (#56)

### DIFF
--- a/watershed_workflow/io.py
+++ b/watershed_workflow/io.py
@@ -8,6 +8,7 @@ import shapely.geometry
 import collections
 import logging
 import h5py
+import datetime
 
 import watershed_workflow.crs
 
@@ -85,8 +86,27 @@ def write_to_shapefile(filename, shps, crs, extra_properties=None):
             c.write({ 'geometry': shapely.geometry.mapping(shp), 'properties': props })
 
 
-def write_dataset_to_hdf5(filename, dataset, attributes, time0=None):
-    """Writes a DatasetCollection and attributes to an HDF5 file."""
+def write_dataset_to_hdf5(filename, dataset, attributes=None, time0=None):
+    """Writes a DatasetCollection and attributes to an HDF5 file.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to write.
+    ts : dict or dataframe
+        Dictionary or dataframe of time series, with keys being the name of the time series
+        and values being the time series data.
+    attributes : dict
+        Dictionary of attributes to write to the HDF5 file.
+    time0 : str or datetime.date object, optional
+        Time to use as the zero time for the time series.  If not provided, the first
+        time in the time series is used.
+
+    Returns
+    -------
+    None
+
+    """
     try:
         os.remove(filename)
     except FileNotFoundError:
@@ -103,12 +123,17 @@ def write_dataset_to_hdf5(filename, dataset, attributes, time0=None):
             'Raster cannot be written as transform is not rectilinear, which is an assumption of simulators.'
         )
     x = np.array([(transform * (i, 0))[0] for i in range(profile['width'])])
-    y = np.array([(transform * (0, j))[0] for j in range(profile['height'])])
-
+    y = np.array([(transform * (0, j))[1] for j in range(profile['height'])])
     if time0 is None:
         time0 = times[0]
-    times = np.array([(t - time0).total_seconds() for t in times])
 
+    if type(time0) is str:
+        time0 = datetime.datetime.strptime(time0, '%Y-%m-%d').date()
+    if attributes is None:
+        attributes = dict()
+    attributes['origin date'] = str(time0)
+    times = np.array([(t - time0).total_seconds() for t in times])
+    times = times.astype(np.int32)
     logging.info('Writing HDF5 file: {}'.format(filename))
     with h5py.File(filename, 'w') as fid:
         fid.create_dataset('time [s]', data=times)
@@ -137,7 +162,25 @@ def write_dataset_to_hdf5(filename, dataset, attributes, time0=None):
 
 
 def write_timeseries_to_hdf5(filename, ts, attributes=None, time0=None):
-    """Writes a time series and attributes to an HDF5 file."""
+    """Writes a time series and attributes to an HDF5 file.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to write.
+    ts : dict or dataframe
+        Dictionary or dataframe of time series, with keys being the name of the time series
+        and values being the time series data.
+    attributes : dict, optional
+        Dictionary of attributes to write to the HDF5 file.
+    time0 : str or datetime.date object, optional
+        Time to use as the zero time for the time series.  If not provided, the first
+        time in the time series is used.
+
+    Returns
+    -------
+    None
+    """
     try:
         os.remove(filename)
     except FileNotFoundError:
@@ -146,10 +189,19 @@ def write_timeseries_to_hdf5(filename, ts, attributes=None, time0=None):
     keys = list(ts.keys())
     keys.remove('time [datetime]')
     times = ts['time [datetime]']
-    if time0 is None:
-        time0 = times[0]
-    times = np.array([(t - time0).total_seconds() for t in times])
 
+    if time0 is None:
+        time0 = times.values[0]
+    if type(time0) is str:
+        time0 = datetime.datetime.strptime(time0, '%Y-%m-%d').date()
+    if attributes is None:
+        attributes = dict()
+    attributes['origin date'] = str(time0)
+    attributes['start date'] = str(times.values[0])
+    attributes['end date']= str(times.values[-1])
+
+    times = np.array([(t - time0).total_seconds() for t in times])
+    times = times.astype(np.int32)
     logging.info('Writing HDF5 file: {}'.format(filename))
     with h5py.File(filename, 'w') as fid:
         fid.create_dataset('time [s]', data=times)

--- a/watershed_workflow/io.py
+++ b/watershed_workflow/io.py
@@ -198,7 +198,7 @@ def write_timeseries_to_hdf5(filename, ts, attributes=None, time0=None):
         attributes = dict()
     attributes['origin date'] = str(time0)
     attributes['start date'] = str(times.values[0])
-    attributes['end date']= str(times.values[-1])
+    attributes['end date'] = str(times.values[-1])
 
     times = np.array([(t - time0).total_seconds() for t in times])
     times = times.astype(np.int32)

--- a/watershed_workflow/land_cover_properties.py
+++ b/watershed_workflow/land_cover_properties.py
@@ -2,12 +2,13 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import logging
+import scipy
 
 import watershed_workflow.warp
 import watershed_workflow.plot
 
 
-def compute_time_series(lai, lc):
+def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, smooth=False, **kwargs):
     """Computes a time-series of LAI for each land cover type that appears
     in the raster.
 
@@ -17,14 +18,23 @@ def compute_time_series(lai, lc):
       The LAI data.
     lc : datasets.Data
       The LULC data.
-       
+    unique_lc : list
+      List of unique land cover types.  If None, will be computed from raster.
+    lc_idx : int
+      Index of the land cover type to use for the time series. Default is -1 (lastest year).
+    smooth : bool
+      Smooth the time series using a Savitzky-Golay filter.
+    kwargs : dict
+      Keyword arguments to pass to scipy.signal.savgol_filter such as 
+      'window_length (default=101)' and 'polyorder (default=3)'.
     Returns
     -------
     lai timeseries : pandas datafame
        LAI time series dataframe with rows as time and columns as land
        type.
     """
-    unique_lc = list(np.unique(lc.data))
+    if unique_lc is None:
+        unique_lc = list(np.unique(lc.data))
     try:
         unique_lc.remove(lc.profile['nodata'])
     except ValueError:
@@ -33,11 +43,33 @@ def compute_time_series(lai, lc):
     df = pd.DataFrame()
     df['time [datetime]'] = lai.times
 
-    for lc in unique_lc:
+    for ilc in unique_lc:
         time_series = [
-            lai.data[i, :, :][np.where(lc.data == lc)].mean() for i in range(len(lai.times))
+            lai.data[itime, :, :][np.where(lc.data[lc_idx, :, :] == ilc)].mean() for itime in range(len(lai.times))
         ]
-        df[f'{lc}'] = time_series
+        col_name = watershed_workflow.sources.manager_modis_appeears.colors[int(ilc)][0]
+        df[f'MODIS {col_name} LAI [-]'] = time_series
+
+    if smooth:
+        # interpolate to daily time series
+        df['time [datetime]'] = pd.to_datetime(df['time [datetime]'])
+        df = df.set_index('time [datetime]')
+        df_daily = df.resample('D').asfreq()
+        df_interpolated = df_daily.interpolate(method='linear')
+
+        # smooth
+        if 'window_length' not in kwargs:
+            kwargs['window_length'] = 101
+        if 'polyorder' not in kwargs:
+            kwargs['polyorder'] = 3
+        df_smoothed = df_interpolated.copy()
+        for k in df_interpolated.columns:
+            df_smoothed[k] = scipy.signal.savgol_filter(df_interpolated[k], **kwargs)
+
+        df_smoothed = df_smoothed.reset_index()
+        df_smoothed['time [datetime]'] = df_smoothed['time [datetime]'].dt.date
+        return df_smoothed
+
     return df
 
 
@@ -46,7 +78,9 @@ def compute_crosswalk_correlation(modis_profile,
                                   nlcd_profile,
                                   nlcd_lc,
                                   plot=True,
-                                  warp=True):
+                                  warp=True,
+                                  unique_nlcd=None,
+                                  unique_modis=None):
     """Compute a map from NLCD indices to MODIS indices using correlation
     of the two rasters.
 
@@ -64,6 +98,10 @@ def compute_crosswalk_correlation(modis_profile,
       Image the correlation matrix.
     warp : bool
       Warps MODIS to NLCD.  Should always be true except for tests.
+    unique_nlcd : list
+      List of unique NLCD indices.  If None, will be computed from raster.
+    unique_modis : list
+      List of unique MODIS indices.  If None, will be computed from raster.
 
     Returns
     -------
@@ -79,15 +117,18 @@ def compute_crosswalk_correlation(modis_profile,
                                                                  dst_crs=nlcd_profile['crs'],
                                                                  dst_height=nlcd_profile['height'],
                                                                  dst_width=nlcd_profile['width'])
+    if unique_nlcd is None:
+        unique_nlcd = list(np.unique(nlcd_lc))
 
-    unique_nlcd = list(np.unique(nlcd_lc))
     if 'nodata' in nlcd_profile:
         try:
             unique_nlcd.remove(nlcd_profile['nodata'])
         except ValueError:
             pass
 
-    unique_modis = list(np.unique(modis_lc))
+    if unique_modis is None:
+        unique_modis = list(np.unique(modis_lc))
+
     if 'nodata' in modis_profile:
         try:
             unique_modis.remove(modis_profile['nodata'])

--- a/watershed_workflow/land_cover_properties.py
+++ b/watershed_workflow/land_cover_properties.py
@@ -8,7 +8,7 @@ import watershed_workflow.warp
 import watershed_workflow.plot
 
 
-def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, smooth=False, **kwargs):
+def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, **kwargs):
     """Computes a time-series of LAI for each land cover type that appears
     in the raster.
 
@@ -22,8 +22,6 @@ def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, smooth=False, **kwar
       List of unique land cover types.  If None, will be computed from raster.
     lc_idx : int
       Index of the land cover type to use for the time series. Default is -1 (lastest year).
-    smooth : bool
-      Smooth the time series using a Savitzky-Golay filter.
     kwargs : dict
       Keyword arguments to pass to scipy.signal.savgol_filter such as 
       'window_length (default=101)' and 'polyorder (default=3)'.
@@ -49,27 +47,6 @@ def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, smooth=False, **kwar
         ]
         col_name = watershed_workflow.sources.manager_modis_appeears.colors[int(ilc)][0]
         df[f'MODIS {col_name} LAI [-]'] = time_series
-
-    if smooth:
-        # interpolate to daily time series
-        df['time [datetime]'] = pd.to_datetime(df['time [datetime]'])
-        df = df.set_index('time [datetime]')
-        df_daily = df.resample('D').asfreq()
-        df_interpolated = df_daily.interpolate(method='linear')
-
-        # smooth
-        if 'window_length' not in kwargs:
-            kwargs['window_length'] = 101
-        if 'polyorder' not in kwargs:
-            kwargs['polyorder'] = 3
-        df_smoothed = df_interpolated.copy()
-        for k in df_interpolated.columns:
-            df_smoothed[k] = scipy.signal.savgol_filter(df_interpolated[k], **kwargs)
-
-        df_smoothed = df_smoothed.reset_index()
-        df_smoothed['time [datetime]'] = df_smoothed['time [datetime]'].dt.date
-        return df_smoothed
-
     return df
 
 

--- a/watershed_workflow/land_cover_properties.py
+++ b/watershed_workflow/land_cover_properties.py
@@ -43,7 +43,8 @@ def compute_time_series(lai, lc, unique_lc=None, lc_idx=-1, **kwargs):
 
     for ilc in unique_lc:
         time_series = [
-            lai.data[itime, :, :][np.where(lc.data[lc_idx, :, :] == ilc)].mean() for itime in range(len(lai.times))
+            lai.data[itime, :, :][np.where(lc.data[lc_idx, :, :] == ilc)].mean()
+            for itime in range(len(lai.times))
         ]
         col_name = watershed_workflow.sources.manager_modis_appeears.colors[int(ilc)][0]
         df[f'MODIS {col_name} LAI [-]'] = time_series

--- a/watershed_workflow/plot.py
+++ b/watershed_workflow/plot.py
@@ -153,7 +153,7 @@ def huc(huc, crs, color='k', ax=None, **kwargs):
     return shply([huc, ], crs, color, ax, **kwargs)
 
 
-def hucs(hucs, crs, color='k', ax=None, outlet_marker=None, outlet_markersize=100, **kwargs):
+def hucs(hucs, crs, color='k', ax=None, outlet_marker=None, outlet_markersize=100, outlet_markercolor='green', **kwargs):
     """Plot a SplitHUCs object.
     
     A wrapper for plot.shply()
@@ -168,6 +168,12 @@ def hucs(hucs, crs, color='k', ax=None, outlet_marker=None, outlet_markersize=10
       See https://matplotlib.org/tutorials/colors/colors.html
     ax : matplotib axes object, optional
       Axes to plot on.  Calls get_ax() if not provided.
+    outlet_marker : matplotlib marker string, optional
+      If provided, also plots the actual points that make up the shape.
+    outlet_markersize : float, optional
+      Size of the outlet marker.
+    outlet_markercolor : matplotlib color string, optional
+      Color of the outlet marker.
     kwargs : dict
       Extra arguments passed to the plotting method, which is likely
       descartes.PolygonPatch.
@@ -189,10 +195,10 @@ def hucs(hucs, crs, color='k', ax=None, outlet_marker=None, outlet_markersize=10
             if not watershed_workflow.utils.is_empty_shapely(p)
         ])
         c = [
-            c for (c, p) in zip(color, hucs.polygon_outlets)
+            c for (c, p) in zip(outlet_markercolor, hucs.polygon_outlets)
             if not watershed_workflow.utils.is_empty_shapely(p)
         ]
-        ax.scatter(x, y, s=outlet_marker, c=c, markersize=outlet_markersize)
+        ax.scatter(x, y, s=outlet_markersize, marker=outlet_marker, c=c)
 
 
 def shapes(shps, crs, color='k', ax=None, **kwargs):

--- a/watershed_workflow/plot.py
+++ b/watershed_workflow/plot.py
@@ -153,7 +153,14 @@ def huc(huc, crs, color='k', ax=None, **kwargs):
     return shply([huc, ], crs, color, ax, **kwargs)
 
 
-def hucs(hucs, crs, color='k', ax=None, outlet_marker=None, outlet_markersize=100, outlet_markercolor='green', **kwargs):
+def hucs(hucs,
+         crs,
+         color='k',
+         ax=None,
+         outlet_marker=None,
+         outlet_markersize=100,
+         outlet_markercolor='green',
+         **kwargs):
     """Plot a SplitHUCs object.
     
     A wrapper for plot.shply()

--- a/watershed_workflow/sources/manager_daymet.py
+++ b/watershed_workflow/sources/manager_daymet.py
@@ -156,7 +156,7 @@ class FileManagerDaymet:
             raise ValueError(f"Invalid date {date}, must be before {self._END}.")
         return date
 
-    def _clean_bounds(self, polygon_or_bounds, crs):
+    def _clean_bounds(self, polygon_or_bounds, crs, buffer):
         """Compute bounds in the required CRS from a polygon or bounds in a given crs"""
         if type(polygon_or_bounds) is dict:
             polygon_or_bounds = watershed_workflow.utils.create_shply(polygon_or_bounds)
@@ -167,7 +167,6 @@ class FileManagerDaymet:
             bounds_ll = watershed_workflow.warp.bounds(polygon_or_bounds, crs,
                                                        watershed_workflow.crs.latlon_crs())
 
-        buffer = 0.01
         feather_bounds = list(bounds_ll[:])
         feather_bounds[0] = np.round(feather_bounds[0] - buffer, 4)
         feather_bounds[1] = np.round(feather_bounds[1] - buffer, 4)
@@ -221,7 +220,8 @@ class FileManagerDaymet:
                  start=None,
                  end=None,
                  variables=None,
-                 force_download=False):
+                 force_download=False,
+                 buffer=0.01):
         """Gets file for a single year and single variable.
 
         Parameters
@@ -241,6 +241,8 @@ class FileManagerDaymet:
           documentation for valid.  Default is [prcp,tmin,tmax,vp,srad].
         force_download : bool
           Download or re-download the file if true.
+        buffer : float
+          Buffer the bounds by this amount, in degrees. The default is 0.01.
 
         Returns
         -------
@@ -274,7 +276,7 @@ class FileManagerDaymet:
                     ', '.join(self.VALID_VARIABLES), var))
 
         # clean bounds
-        bounds = self._clean_bounds(polygon_or_bounds, crs)
+        bounds = self._clean_bounds(polygon_or_bounds, crs, buffer=buffer)
 
         # download files
         filenames = []

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -97,6 +97,7 @@ class FileManagerMODISAppEEARS:
     }
 
     def __init__(self, login_token=None):
+        """Create a new manager for MODIS data."""
         self.name = 'MODIS'
         self.names = watershed_workflow.sources.names.Names(
             self.name, 'land_cover', self.name,
@@ -422,7 +423,8 @@ class FileManagerMODISAppEEARS:
                  end=None,
                  variables=None,
                  force_download=False,
-                 task=None):
+                 task=None,
+                 filenames=None):
         """Get dataset corresponding to MODIS data from the AppEEARS data portal.
 
         Note that AppEEARS requires the constrution of a request, and
@@ -451,6 +453,8 @@ class FileManagerMODISAppEEARS:
           If a request has already been created, use this task to
           access the data rather than creating a new request.  Default
           means to create a new request.
+        filenames : list of str, optional
+            If a list of filenames is provided, use these rather than creating a new request.
         
         Returns
         -------
@@ -468,7 +472,15 @@ class FileManagerMODISAppEEARS:
           task tuple for use in a future call to get_data().
 
         """
-        if task is None:
+        if filenames is not None:
+            # read the file
+            assert variables is not None, "Must provide variables if providing filenames."
+            s = watershed_workflow.datasets.State()
+            for filename,var in zip(filenames,variables):
+                s[var] = self._read_file(filename, var)
+            return s
+
+        if task is None and filenames is None:
             if polygon_or_bounds is None or crs is None:
                 raise RuntimeError(
                     'Must provide either polgyon_or_bounds and crs or task arguments.')

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -476,7 +476,7 @@ class FileManagerMODISAppEEARS:
             # read the file
             assert variables is not None, "Must provide variables if providing filenames."
             s = watershed_workflow.datasets.State()
-            for filename,var in zip(filenames,variables):
+            for filename, var in zip(filenames, variables):
                 s[var] = self._read_file(filename, var)
             return s
 

--- a/watershed_workflow/utils.py
+++ b/watershed_workflow/utils.py
@@ -412,7 +412,6 @@ def smooth(data, window_length=61, polyorder=2, axis=0, mode='wrap', **kwargs):
 
 
 def generate_rings(obj):
-
     """Generator for a fiona shape's coordinates object and yield rings.
 
     As long as the input is conforming, the type of the geometry doesn't matter.

--- a/watershed_workflow/utils.py
+++ b/watershed_workflow/utils.py
@@ -317,7 +317,8 @@ def compute_average_year(data, output_nyears=1, filter=False, **kwargs):
 
     """
     nyears = data.shape[0] // 365
-
+    if nyears == 0:
+        raise ValueError('Not enough data to compute average year. Need at least 365 days.')
     data = data[0:nyears * 365, :, :].reshape(nyears, 365, data.shape[1], data.shape[2])
     data = data.mean(axis=0)
 
@@ -327,9 +328,8 @@ def compute_average_year(data, output_nyears=1, filter=False, **kwargs):
             kwargs.setdefault(k, v)
 
         data = scipy.signal.savgol_filter(data, **kwargs)
-
     if output_nyears != 1:
-        data = np.tile(data, (nyears, 1, 1))
+        data = np.tile(data, (output_nyears, 1, 1))
     return data
 
 

--- a/watershed_workflow/utils.py
+++ b/watershed_workflow/utils.py
@@ -376,7 +376,43 @@ def interpolate_in_time(times, data, start, end, dt=None, **kwargs):
     return new_times, new_data
 
 
+def smooth(data, window_length=61, polyorder=2, axis=0, mode='wrap', **kwargs):
+    """Smooths fixed-interval time-series data using a Sav-Gol filter from scipy.
+
+    Note that this wrapper just sets some sane default values for
+    daily data -- one could just as easily call
+    scipy.signal.savgol_filter themselves.
+    
+    Parameters
+    ----------
+    data : np.ndarray-like
+      The data to smooth.  Note that the expectation is that the time
+      axis is the 0th axis.
+    window_length : int, 61
+      Length of the moving window over which to fit the polynomial.
+    polyorder : int, 2
+      Order of the fitting polynomial.
+    axis : int, 0
+      Time axis over which to smooth.
+    mode : str, 'wrap'
+      See scipy.signal.savgol_filter documentation, but 'wrap' is the
+      best bet for data in multiples of years.
+    **kwargs : see scipy.signal.savgol_filter
+
+    Returns
+    -------
+    np.ndarray
+      Smoothed data in the same shape as data
+    """
+    kwargs['window_length'] = window_length
+    kwargs['polyorder'] = polyorder
+    kwargs['axis'] = axis
+    kwargs['mode'] = mode
+    return scipy.signal.savgol_filter(data, **kwargs)
+
+
 def generate_rings(obj):
+
     """Generator for a fiona shape's coordinates object and yield rings.
 
     As long as the input is conforming, the type of the geometry doesn't matter.


### PR DESCRIPTION
* updated modis manager to allow reading local files if available; minor fix to the cross-walk to show only landcover types within the watershed

* added smooth option to generate smoothed daily LAI data

* fixed a bug in compute_time_series() to compute different LAI for corresponding landcover types

* updated write_timeseries_to_hdf5() to allow string as date formate; added details to attributes by default

* updated write_dateset_to_hdf5() to allow string format for time0; added origin date to attributes

* fixed a bug in compute_average_year() to take the actual user input as nyears

* fixed scatter plot for outlets

* fixed a bug in writing daymet y-coordinates

* added buffer as an option for downloading Daymet; the default 0.01 can sometimes be small for watersheds