### PR TITLE
Add notebook<7.0.0 constraint.

### DIFF
--- a/environments/create_envs.py
+++ b/environments/create_envs.py
@@ -42,6 +42,7 @@ PACKAGES_EXTRAS_DEV=[
 PACKAGES_USER_BASE=['ipython',
                'jupyterlab',
                'ipykernel',
+               'notebook<7.0.0',
                'nb_conda',
                'nb_conda_kernels',
                'papermill',


### PR DESCRIPTION
Adds constraint on notebook - nb_conda throws a lot of errors when being installed without this constraint on OSX.

Have not tested on linux, but could if preferred before merging.