### PR TITLE
New densification methods, variable quad length-scales. increased flexibility for defining quad widths, depths

### DIFF
--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1342,7 +1342,7 @@ def tessalate_river_aligned(hucs,
                             internal_boundaries=None,
                             hole_points=None,
                             diagnostics=False,
-                            tol = 1,
+                            tol=1,
                             ax=None,
                             **kwargs):
     """Tessalate HUCs using river-aligned quads along the corridor and triangles away from it.
@@ -1407,9 +1407,14 @@ def tessalate_river_aligned(hucs,
                                                                   ax=ax)
 
     # triangulate the rest
-    tri_res = watershed_workflow.triangulate(hucs_without_outlet, rivers, corrs,
-                                             internal_boundaries, hole_points,
-                                             diagnostics, tol=tol, **kwargs)
+    tri_res = watershed_workflow.triangulate(hucs_without_outlet,
+                                             rivers,
+                                             corrs,
+                                             internal_boundaries,
+                                             hole_points,
+                                             diagnostics,
+                                             tol=tol,
+                                             **kwargs)
     tri_verts = tri_res[0]
     tri_conn = tri_res[1]
 

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1406,7 +1406,7 @@ def tessalate_river_aligned(hucs,
                                                                   ax=ax)
 
     # triangulate the rest
-    tri_res = watershed_workflow.triangulate(hucs_without_outlets,
+    tri_res = watershed_workflow.triangulate(hucs_without_outlet,
                                              rivers,
                                              corrs,
                                              internal_boundaries,

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1406,12 +1406,8 @@ def tessalate_river_aligned(hucs,
                                                                   ax=ax)
 
     # triangulate the rest
-    tri_res = watershed_workflow.triangulate(hucs_without_outlet,
-                                             rivers,
-                                             corrs,
-                                             internal_boundaries,
-                                             hole_points,
-                                             diagnostics,
+    tri_res = watershed_workflow.triangulate(hucs_without_outlet, rivers, corrs,
+                                             internal_boundaries, hole_points, diagnostics,
                                              **kwargs)
     tri_verts = tri_res[0]
     tri_conn = tri_res[1]

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1390,6 +1390,7 @@ def tessalate_river_aligned(hucs,
     logging.info('Creating stream-aligned mesh...')
     quad_conn, corrs = watershed_workflow.river_mesh.create_rivers_meshes(rivers=rivers,
                                                                           widths=river_width,
+                                                                          width_prop = 'StreamOrder',
                                                                           enforce_convexity=True,
                                                                           ax=ax,
                                                                           label=False)

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1342,7 +1342,6 @@ def tessalate_river_aligned(hucs,
                             internal_boundaries=None,
                             hole_points=None,
                             diagnostics=False,
-                            tol=1,
                             ax=None,
                             **kwargs):
     """Tessalate HUCs using river-aligned quads along the corridor and triangles away from it.
@@ -1407,13 +1406,12 @@ def tessalate_river_aligned(hucs,
                                                                   ax=ax)
 
     # triangulate the rest
-    tri_res = watershed_workflow.triangulate(hucs_without_outlet,
+    tri_res = watershed_workflow.triangulate(hucs_without_outlets,
                                              rivers,
                                              corrs,
                                              internal_boundaries,
                                              hole_points,
                                              diagnostics,
-                                             tol=tol,
                                              **kwargs)
     tri_verts = tri_res[0]
     tri_conn = tri_res[1]

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1342,6 +1342,7 @@ def tessalate_river_aligned(hucs,
                             internal_boundaries=None,
                             hole_points=None,
                             diagnostics=False,
+                            tol = 1,
                             ax=None,
                             **kwargs):
     """Tessalate HUCs using river-aligned quads along the corridor and triangles away from it.
@@ -1408,7 +1409,7 @@ def tessalate_river_aligned(hucs,
     # triangulate the rest
     tri_res = watershed_workflow.triangulate(hucs_without_outlet, rivers, corrs,
                                              internal_boundaries, hole_points,
-                                             diagnostics, **kwargs)
+                                             diagnostics, tol=tol, **kwargs)
     tri_verts = tri_res[0]
     tri_conn = tri_res[1]
 

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1353,9 +1353,11 @@ def tessalate_river_aligned(hucs,
        required by the river corridor.
     rivers : list[River]
        The rivers to mesh with quads
-    river_width : float or dict
+    river_width : float or dict or callable or boolean 
        Width of the quads, either a float or a dictionary providing a
        {StreamOrder : width} mapping.
+       Or a function (callable) that computer width using node properties
+       Or boolean, where True means, width for each reach is explicitely provided properties as "width"
     river_n_quads : int, optional
        Number of quads across the river.  Currently only 1 is
        supported (the default).

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1390,7 +1390,6 @@ def tessalate_river_aligned(hucs,
     logging.info('Creating stream-aligned mesh...')
     quad_conn, corrs = watershed_workflow.river_mesh.create_rivers_meshes(rivers=rivers,
                                                                           widths=river_width,
-                                                                          width_prop = 'StreamOrder',
                                                                           enforce_convexity=True,
                                                                           ax=ax,
                                                                           label=False)

--- a/watershed_workflow/densification.py
+++ b/watershed_workflow/densification.py
@@ -413,7 +413,10 @@ def _remove_sharp_angles(river,
                 while remove:
                     remove = treat_small_angle_between_child_nodes(node,
                                                                    angle_limit=junction_angle_limit)
-                    assert (node.is_locally_continuous())
+                    if not node.is_locally_continuous():
+                        print(node.properties['ID'])
+                    #assert (node.is_locally_continuous())
+           
 
         assert (river.is_continuous())
 
@@ -565,6 +568,7 @@ def treat_small_angle_between_child_nodes(node, angle_limit=10):
                         grandchild_seg_coords[-1] = new_junction
                         grandchild.segment = shapely.geometry.LineString(grandchild_seg_coords)
                         node.addChild(grandchild)
+                        print('this was executed')
                     child.remove()
 
             # we changed things -- return True so this can be called

--- a/watershed_workflow/densification.py
+++ b/watershed_workflow/densification.py
@@ -550,7 +550,7 @@ def treat_small_angle_between_child_nodes(node, angle_limit=10):
             new_node_coords = watershed_workflow.utils.treat_segment_collinearity(new_node_coords)
             node.segment = shapely.geometry.LineString(new_node_coords)
 
-            for child in node.children:
+            for child in list(node.children):
                 child_coords = child.segment.coords[:]
                 if len(child_coords) > 2:
                     # reach has > 2 points, so we can safely remove the last one

--- a/watershed_workflow/densification.py
+++ b/watershed_workflow/densification.py
@@ -417,7 +417,7 @@ def _remove_sharp_angles(river,
                                                                    angle_limit=junction_angle_limit)
                     if not node.is_locally_continuous():
                         print(node.properties['ID'])
-                    #assert (node.is_locally_continuous())
+                    assert (node.is_locally_continuous())
 
         assert (river.is_continuous())
 
@@ -570,7 +570,6 @@ def treat_small_angle_between_child_nodes(node, angle_limit=10):
                         grandchild_seg_coords[-1] = new_junction
                         grandchild.segment = shapely.geometry.LineString(grandchild_seg_coords)
                         node.addChild(grandchild)
-                        print('this was executed')
                     child.remove()
 
             # we changed things -- return True so this can be called

--- a/watershed_workflow/densification.py
+++ b/watershed_workflow/densification.py
@@ -36,10 +36,10 @@ def densify_rivers_new(rivers, limit=50):
             if isinstance(limit, bool):
                 if limit and 'target_length' in node.properties:
                     target_length = node.properties['target_length']
-                else: 
+                else:
                     raise RuntimeError('not a valid option to provide width')
             else:
-                    target_length = limit 
+                target_length = limit
             node.segment = resample_linestring_preserve_ends(node.segment, target_length)
 
     mins = []
@@ -106,15 +106,14 @@ def densify_node_segments(node, node_raw, limit=100):
     seg_coords = list(node.segment.coords)  # coordinates of node.segment to be densified
     seg_coords_densified = seg_coords.copy()  # segment coordinates densified
 
-
     if isinstance(limit, bool):
         if limit and 'target_length' in node.properties:
             target_length = node.properties['target_length']
-        else: 
+        else:
             raise RuntimeError('not a valid option to provide width')
     else:
-            target_length = limit
-            
+        target_length = limit
+
     j = 0
     for i in range(len(seg_coords) - 1):
         section_length = watershed_workflow.utils.distance(seg_coords[i], seg_coords[i + 1])
@@ -273,9 +272,12 @@ def resample_linestring_preserve_ends(seg, initial_spacing):
     num_segments = max(int(round(length / initial_spacing)), 1)
 
     adjusted_spacing = length / num_segments
-    
-    redensified_points = [seg.interpolate(distance).coords[0] for distance in [i * adjusted_spacing for i in range(num_segments + 1)]]
-    
+
+    redensified_points = [
+        seg.interpolate(distance).coords[0]
+        for distance in [i * adjusted_spacing for i in range(num_segments + 1)]
+    ]
+
     new_seg = shapely.geometry.LineString(redensified_points)
     return new_seg
 
@@ -416,7 +418,6 @@ def _remove_sharp_angles(river,
                     if not node.is_locally_continuous():
                         print(node.properties['ID'])
                     #assert (node.is_locally_continuous())
-           
 
         assert (river.is_continuous())
 
@@ -434,7 +435,8 @@ def remove_sharp_angles_from_seg(node, angle_limit=10):
         seg_down = shapely.geometry.LineString([seg_coords[i + 1], seg_coords[i + 2]])
         angle = watershed_workflow.river_mesh.angle_rivers_segs(ref_seg=seg_down, seg=seg_up)
         if angle > 360 - angle_limit or angle < angle_limit:
-            logging.info(f"removing sharp angle in segment: {angle} for node {node.properties['ID']}")
+            logging.info(
+                f"removing sharp angle in segment: {angle} for node {node.properties['ID']}")
             if len(seg_coords) > 3:
                 new_point = shapely.geometry.Polygon(
                     [seg_coords[i], seg_coords[i + 1], seg_coords[i + 2]]).centroid
@@ -477,7 +479,7 @@ def treat_node_junctions_for_sharp_angles(node, angle_limit=10):
         seg2 = child.segment
         is_changed, seg1, seg2 = remove_sharp_angles_at_reach_junctions(seg1,
                                                                         seg2,
-                                                                        angle_limit=angle_limit, 
+                                                                        angle_limit=angle_limit,
                                                                         id=node.properties['ID'])
 
         if is_changed:
@@ -589,20 +591,24 @@ def treat_small_angle_btw_river_huc(river, hucs, angle_limit=20):
     # the intersection_point might be a MultiPoint with intersections at leaf tips
     # find all leaf tip points and exclude coinciding intersection points
     leaf_tips = [shapely.geometry.Point(leaf.segment.coords[0]) for leaf in river.leaf_nodes()]
-    
+
     for i, seg in enumerate(hucs.segments):
 
         if seg.intersects(river_mls):  # does huc segment intersect with the river
             intersection_point = seg.intersection(river_mls)
             intersection_found = True
             if isinstance(intersection_point, shapely.geometry.multipoint.MultiPoint):
-                non_coinciding_points = [p for p in intersection_point if not any(p.distance(point) < 1e-6 for point in leaf_tips)]
+                non_coinciding_points = [
+                    p for p in intersection_point
+                    if not any(p.distance(point) < 1e-6 for point in leaf_tips)
+                ]
                 # Check if there's exactly one point left after filtering
                 if len(non_coinciding_points) == 1:
                     intersection_point = non_coinciding_points[0]
                 elif len(non_coinciding_points) > 1:
                     print([point.coords[:] for point in non_coinciding_points])
-                    raise ValueError("The intersection_point must be a single shapely.geometry.Point object")
+                    raise ValueError(
+                        "The intersection_point must be a single shapely.geometry.Point object")
                 elif not non_coinciding_points:
                     intersection_found = False
 
@@ -628,7 +634,7 @@ def treat_small_angle_btw_river_huc(river, hucs, angle_limit=20):
                     if len(parent_node.segment.coords) > 2:
                         ref_seg = shapely.geometry.LineString(
                             parent_node.segment.coords[ind_intersection_point:ind_intersection_point
-                                                    + 2])
+                                                       + 2])
                     else:
                         ref_seg = parent_node.segment
 
@@ -641,12 +647,14 @@ def treat_small_angle_btw_river_huc(river, hucs, angle_limit=20):
                 ]
 
                 angle_check = check_abs_smaller(
-                    river_angles,
-                    angle_limit)  # is any angle between river and huc segment smaller than the limit?
+                    river_angles, angle_limit
+                )  # is any angle between river and huc segment smaller than the limit?
 
                 if angle_check[0]:
                     river_angle = river_angles[angle_check[1]]
-                    logging.info(f"removing sharp angle between river and huc: {river_angle} for node {parent_node.properties['ID']}")
+                    logging.info(
+                        f"removing sharp angle between river and huc: {river_angle} for node {parent_node.properties['ID']}"
+                    )
                     if river_angle > 0:
                         rotate_angle = angle_limit - river_angle + 5
                     else:

--- a/watershed_workflow/densification.py
+++ b/watershed_workflow/densification.py
@@ -82,11 +82,21 @@ def densify_node_segments(node, node_raw, limit=100):
 
     seg_coords = list(node.segment.coords)  # coordinates of node.segment to be densified
     seg_coords_densified = seg_coords.copy()  # segment coordinates densified
+
+
+    if isinstance(limit, bool):
+        if limit and 'target_length' in node.properties:
+            target_length = node.properties['target_length']
+        else: 
+            raise RuntimeError('not a valid option to provide width')
+    else:
+            target_length = limit
+            
     j = 0
     for i in range(len(seg_coords) - 1):
         section_length = watershed_workflow.utils.distance(seg_coords[i], seg_coords[i + 1])
-        if section_length > limit:
-            number_new_points = int(section_length // limit)
+        if section_length > target_length:
+            number_new_points = int(section_length // target_length)
             end_points = [seg_coords[i],
                           seg_coords[i + 1]]  # points betwen which more points will be added
             if node_raw is not None:

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -723,7 +723,8 @@ def filterSmallRivers(rivers, count):
 def merge(river, tol=_tol):
     """Remove inner branches that are short, combining branchpoints as needed.
 
-    This function merges the "short" segment into the parent segment
+    This function merges the "short" segment into the child segment if it is a junction tributary with one child
+    or into the parent segment otherwise
 
     """
     for node in list(river.preOrder()):
@@ -731,14 +732,19 @@ def merge(river, tol=_tol):
             logging.info(
                 "  ...cleaned inner segment of length %g at centroid %r with id %r" %
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
+            
+            if len(list(node.siblings()))>0 and len(node.children)==1: # non junction tributary with one child
+                node.merge_with_child()  
+            elif len(node.children)==0: # if the leaf node is too small
+                node.remove()       
+            else: 
+                for sibling in list(node.siblings()):
+                    sibling.moveCoordinate(-1, node.segment.coords[0])
+                    sibling.remove()
+                    node.addChild(sibling)
 
-            for sibling in list(node.siblings()):
-                sibling.moveCoordinate(-1, node.segment.coords[0])
-                sibling.remove()
-                node.addChild(sibling)
-
-            assert (len(list(node.siblings())) == 0)
-            node.merge()
+                assert (len(list(node.siblings())) == 0)
+                node.merge()
 
 
 def simplify(river, tol=_tol):

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -733,8 +733,8 @@ def merge(river, tol=_tol):
                 "  ...cleaned inner segment of length %g at centroid %r with id %r" %
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
             
-            if len(list(node.siblings()))>0 and len(node.children)==1: # non junction tributary with one child
-                node.merge_with_child()  
+            if len(list(node.siblings()))>0 and len(node.children)==1: # junction tributary with one child
+                node.children[0].merge(properties_from = 'self')  
             elif len(node.children)==0: # if the leaf node is too small
                 node.remove()       
             else: 

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -732,12 +732,14 @@ def merge(river, tol=_tol):
             logging.info(
                 "  ...cleaned inner segment of length %g at centroid %r with id %r" %
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
-            
-            if len(list(node.siblings()))>0 and len(node.children)==1: # junction tributary with one child
-                node.merge(to = 'child')  
-            elif len(node.children)==0: # if the leaf node is too small
-                node.remove()       
-            else: 
+
+            if len(list(node.siblings())) > 0 and len(node.children) == 1:
+                # junction tributary with one child
+                node.merge(to='child')
+            elif len(node.children) == 0:
+                # if the leaf node is too small
+                node.remove()
+            else:
                 for sibling in list(node.siblings()):
                     sibling.moveCoordinate(-1, node.segment.coords[0])
                     sibling.remove()

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -731,12 +731,12 @@ def merge(river, tol=_tol):
             logging.info(
                 "  ...cleaned inner segment of length %g at centroid %r with id %r" %
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
-
-            for sibling in node.siblings():
+            
+            for sibling in list(node.siblings()):
                 sibling.moveCoordinate(-1, node.segment.coords[0])
                 sibling.remove()
                 node.addChild(sibling)
-
+                         
             assert (len(list(node.siblings())) == 0)
             node.merge()
 

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -734,7 +734,7 @@ def merge(river, tol=_tol):
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
             
             if len(list(node.siblings()))>0 and len(node.children)==1: # junction tributary with one child
-                node.children[0].merge(properties_from = 'self')  
+                node.merge(to = 'child')  
             elif len(node.children)==0: # if the leaf node is too small
                 node.remove()       
             else: 

--- a/watershed_workflow/hydrography.py
+++ b/watershed_workflow/hydrography.py
@@ -731,12 +731,12 @@ def merge(river, tol=_tol):
             logging.info(
                 "  ...cleaned inner segment of length %g at centroid %r with id %r" %
                 (node.segment.length, node.segment.centroid.coords[0], node.properties['ID']))
-            
+
             for sibling in list(node.siblings()):
                 sibling.moveCoordinate(-1, node.segment.coords[0])
                 sibling.remove()
                 node.addChild(sibling)
-                         
+
             assert (len(list(node.siblings())) == 0)
             node.merge()
 

--- a/watershed_workflow/mesh.py
+++ b/watershed_workflow/mesh.py
@@ -1597,8 +1597,10 @@ def merge_meshes(meshes):
 
 def merge_mesh(mesh1, mesh2):  # --THIS OPTION TO BE ADDED LATER-- #transfer_labeled_sets=True
     """merge two meshes (mesh.Mesh2D objects)"""
-   
-    assert len(mesh1.labeled_sets) + len(mesh2.labeled_sets) == 0, "to-be-merged meshes should not have labeled sets, they must be added after merging"
+
+    assert len(mesh1.labeled_sets) + len(
+        mesh2.labeled_sets
+    ) == 0, "to-be-merged meshes should not have labeled sets, they must be added after merging"
     combined_coords = mesh1.coords.tolist()
     # mapping for adjusting coord indices
     mapping = { i: i for i in range(mesh2.num_nodes) }

--- a/watershed_workflow/mesh.py
+++ b/watershed_workflow/mesh.py
@@ -1595,11 +1595,12 @@ def merge_meshes(meshes):
     return m2_combined
 
 
-def merge_mesh(mesh1, mesh2):  # --THIS OPTION TO BE ADDED LATER-- #transfer_labeled_sets=True
+def merge_mesh(mesh1, mesh2):
     """merge two meshes (mesh.Mesh2D objects)"""
+    # --THIS OPTION TO BE ADDED LATER-- #transfer_labeled_sets=True
+    assert len(mesh1.labeled_sets) + len(mesh2.labeled_sets) == 0, \
+        'to-be-merged meshes should not have labeled sets, they must be added after merging'
 
-    assert len(mesh1.labeled_sets) + len(
-        mesh2.labeled_sets) == 0, "to-be-merged meshes should not have labeled sets, they must be added after merging"
     combined_coords = mesh1.coords.tolist()
     # mapping for adjusting coord indices
     mapping = { i: i for i in range(mesh2.num_nodes) }

--- a/watershed_workflow/mesh.py
+++ b/watershed_workflow/mesh.py
@@ -1599,8 +1599,7 @@ def merge_mesh(mesh1, mesh2):  # --THIS OPTION TO BE ADDED LATER-- #transfer_lab
     """merge two meshes (mesh.Mesh2D objects)"""
 
     assert len(mesh1.labeled_sets) + len(
-        mesh2.labeled_sets
-    ) == 0, "to-be-merged meshes should not have labeled sets, they must be added after merging"
+        mesh2.labeled_sets) == 0, "to-be-merged meshes should not have labeled sets, they must be added after merging"
     combined_coords = mesh1.coords.tolist()
     # mapping for adjusting coord indices
     mapping = { i: i for i in range(mesh2.num_nodes) }

--- a/watershed_workflow/plot.py
+++ b/watershed_workflow/plot.py
@@ -188,6 +188,7 @@ def get_ax(crs,
         newfig = False
 
     if window is None:
+
         def _get_ax(axargs, ax_kwargs):
             if crs is None:
                 # no crs, just get an ax -- you deal with it.
@@ -201,12 +202,13 @@ def get_ax(crs,
                 ax_kwargs['projection'] = projection
                 ax = fig.add_subplot(*axargs, **ax_kwargs)
             return ax
-        
+
         if axgrid is None:
             if nrow == 1 and ncol == 1:
                 index = 1
             if index is None:
-                ax = [[_get_ax([nrow, ncol, i*(ncol)+j+1], ax_kwargs) for j in range(ncol)] for i in range(nrow)]
+                ax = [[_get_ax([nrow, ncol, i * (ncol) + j + 1], ax_kwargs) for j in range(ncol)]
+                      for i in range(nrow)]
                 if nrow == 1:
                     ax = ax[0]
                 elif ncol == 1:
@@ -214,7 +216,7 @@ def get_ax(crs,
             else:
                 ax = _get_ax([nrow, ncol, index], ax_kwargs)
         else:
-            ax = _get_ax([axgrid,], ax_kwargs)
+            ax = _get_ax([axgrid, ], ax_kwargs)
 
     else:
         if crs is None:

--- a/watershed_workflow/regions.py
+++ b/watershed_workflow/regions.py
@@ -304,7 +304,7 @@ def add_regions_by_stream_order(m2, river, river_id=0):
             m2.labeled_sets.append(ls2)
 
 
-def add_region_by_reach_id(m2, river, reach_ids=None, labels = None):
+def add_region_by_reach_id(m2, river, reach_ids=None, labels=None):
     """Add labeled sets to m2 for reaches of each stream order .
      
     Parameters:

--- a/watershed_workflow/regions.py
+++ b/watershed_workflow/regions.py
@@ -304,7 +304,7 @@ def add_regions_by_stream_order(m2, river, river_id=0):
             m2.labeled_sets.append(ls2)
 
 
-def add_region_by_reach_id(m2, river, reach_ids=None):
+def add_region_by_reach_id(m2, river, reach_ids=None, labels = None):
     """Add labeled sets to m2 for reaches of each stream order .
      
     Parameters:
@@ -319,7 +319,7 @@ def add_region_by_reach_id(m2, river, reach_ids=None):
 
     from collections import defaultdict
 
-    if reach_ids != None:
+    if labels == None:
         labels = []
         for id in reach_ids:
             label = f'reach with id {id}'

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -227,8 +227,10 @@ def create_river_mesh(river,
 
     """
     # creating a polygon for river corridor by dilating the river tree
-    if type(widths) == dict:
+    if isinstance(widths, dict):
         dilation_width = min(dilation_width, min(widths.values()))
+    elif isinstance(widths, int):
+        dilation_width = min(dilation_width, widths)
   
     corr = create_river_corridor(river, dilation_width)
 
@@ -305,10 +307,9 @@ def create_river_corridor(river, width):
 
     logging.info(f"  -- river min seg length: {min(mins)}")
 
-    print('delta', delta)
-
     # Currently this same for the whole river, should we change it reachwise?
     length_scale = max(2.1 * delta, min(mins) - 8*delta)
+  
     logging.info(f"  -- merging points closer than {length_scale} m along the river corridor")
 
     # buffer by the width

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -776,35 +776,6 @@ def convexity_enforcement(river, corr, gid_shift):
     return shapely.geometry.Polygon(corr_coords_new)
 
 
-
-
-
-from shapely.geometry import MultiPoint, Point, Polygon, LineString
-from scipy.optimize import linear_sum_assignment
-
-# def make_convex_using_hull(points):
-#     # Compute the convex hull
-#     convex_hull = MultiPoint(points).convex_hull
-#     hull_coords = list(convex_hull.exterior.coords[:-1])  # exclude the closing point which is same as the first
-
-#     # Create a dictionary to map point coordinates to their nearest points on the convex hull
-#     point_to_hull_point = {}
-#     for point in points:
-#         shapely_point = Point(point)
-#         if not shapely_point.within(convex_hull):
-#             # Find the nearest point on the convex hull
-#             nearest_point = min(hull_coords, key=lambda hull_point: shapely_point.distance(Point(hull_point)))
-#             point_to_hull_point[point] = nearest_point
-
-#     # Create the new list of points, replacing non-hull points with their nearest hull points
-#     new_points = [point_to_hull_point.get(point, point) for point in points]
-
-#     return new_points
-
-from scipy.optimize import minimize
-from shapely.geometry import MultiPoint, Point, Polygon
-from shapely.ops import nearest_points
-
 def make_convex_using_hull(points):
     convex_ring = shapely.geometry.Polygon(points).convex_hull.exterior
     for i, point in enumerate(points):
@@ -813,36 +784,6 @@ def make_convex_using_hull(points):
         new_point = shapely.ops.nearest_points(convex_ring, p)[0].coords[0]
         points[i] = new_point
         return points
-    # convex_hull = MultiPoint(points).convex_hull
-    # original_polygon = Polygon(points)
-    
-    # # Using the convex hull as a continuous geometry
-    # hull_line = LineString(convex_hull.exterior.coords)
-    
-    # adjusted_points = []
-    # for point in points:
-    #     shapely_point = Point(point)
-    #     # Find the nearest point on the hull to this point
-    #     nearest_point_on_hull = nearest_points(shapely_point, hull_line)[1]
-        
-    #     # If the point is a vertex of the convex hull, it should not be moved
-    #     if shapely_point.equals(nearest_point_on_hull):
-    #         adjusted_points.append(point)
-    #     else:
-    #         # Move points not on the hull to the nearest location on the hull
-    #         adjusted_point = nearest_point_on_hull.coords[0]
-    #         adjusted_points.append(adjusted_point)
-
-    # if watershed_workflow.utils.is_convex(adjusted_points):
-    #     return adjusted_points
-    # else:
-    #     # In rare cases, adjustments might still not yield a convex polygon
-    #     # Further analysis or manual intervention may be required.
-    #     raise ValueError(f"Adjusted polygon is not convex. Further optimization needed. {adjusted_points}")
-
-
-
-
 
 def make_convex_by_nudge(points):
     """Nudges the neck-points of the junction until the element is convex.

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -49,7 +49,7 @@ def _isOverlappingCorridor(corr, river):
         # there is an overlap upstream of the junction of two tributaries,
         # creating a hole
         return 2
-    n=0
+    n = 0
     if not _isExpectedNumPoints(corr, river, n):
         # overlaps at the junction result in losing points in the corridor polygon.
         return 1
@@ -78,6 +78,7 @@ def _isExpectedNumPoints(corr, river, n):
         n = n + 2 * (len(node.segment.coords) - 1)
     n = n - n_child.count(0) + n_child.count(2) + 2 * n_child.count(3) + 3 * n_child.count(4)
     return len(corr.exterior.coords) - 1 == n
+
 
 def create_rivers_meshes(rivers, widths=8, enforce_convexity=True, ax=None, label=True):
     """Returns list of elems and river corridor polygons for a given list of river trees

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -226,10 +226,11 @@ def create_river_mesh(river,
         The polygon of all elements, stores the coordinates.
 
     """
+
     # creating a polygon for river corridor by dilating the river tree
     if isinstance(widths, dict):
         dilation_width = min(dilation_width, min(widths.values()))
-    elif isinstance(widths, int):
+    elif isinstance(widths, int) and not isinstance(widths, bool):
         dilation_width = min(dilation_width, widths)
 
     corr = create_river_corridor(river, dilation_width)

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -67,7 +67,7 @@ def _isOverlappingCorridors(corrs, rivers):
     return False
 
 
-def _isExpectedNumPoints(corr, river):
+def _isExpectedNumPoints(corr, river, n):
     """Check if the points on the corridor are same as calculated theoretically"""
     n_child = []
     for node in river.preOrder():
@@ -76,8 +76,7 @@ def _isExpectedNumPoints(corr, river):
     for node in river.preOrder():
         n = n + 2 * (len(node.segment.coords) - 1)
     n = n - n_child.count(0) + n_child.count(2) + 2 * n_child.count(3) + 3 * n_child.count(4)
-    return (len(corr.exterior.coords) - 1 == n), n
-
+    return len(corr.exterior.coords) - 1 == n
 
 def create_rivers_meshes(rivers, widths=8, enforce_convexity=True, ax=None, label=True):
     """Returns list of elems and river corridor polygons for a given list of river trees
@@ -363,10 +362,9 @@ def create_river_corridor(river, width):
 
     # create the polgyon
     corr3 = shapely.geometry.Polygon(corr3_p)
-
+    n = 0
     # check if the points on the river corridor are same as calculated theoretically
-    is_broken, n = _isExpectedNumPoints(corr3, river)
-    if not _isExpectedNumPoints(corr3, river):
+    if not _isExpectedNumPoints(corr3, river, n):
         raise RuntimeError(
             f"Broken dilation -- expected {n} coords, got {len(corr3.exterior.coords[:])}"
             " -- recommend running with ax argument to tessalate_river_aligned() to debug!")

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -77,7 +77,7 @@ def _isExpectedNumPoints(corr, river):
     return (len(corr.exterior.coords) - 1 == n)
 
 
-def create_rivers_meshes(rivers, widths=8, enforce_convexity=True, ax=None, label=True):
+def create_rivers_meshes(rivers, widths=8, width_prop = 'StreamOrder', enforce_convexity=True, ax=None, label=True):
     """Returns list of elems and river corridor polygons for a given list of river trees
 
     Parameters:
@@ -166,6 +166,7 @@ def create_rivers_meshes(rivers, widths=8, enforce_convexity=True, ax=None, labe
             gid_shift = np.max([max(map(int, elem)) for elem in elems]) + 1
         elems_river, corr = create_river_mesh(river,
                                               widths=widths,
+                                              width_prop = width_prop,
                                               enforce_convexity=enforce_convexity,
                                               gid_shift=gid_shift,
                                               ax=ax)
@@ -181,6 +182,7 @@ def create_rivers_meshes(rivers, widths=8, enforce_convexity=True, ax=None, labe
 
 def create_river_mesh(river,
                       widths=8,
+                      width_prop = 'StreamOrder',
                       enforce_convexity=True,
                       gid_shift=0,
                       dilation_width=4,
@@ -230,9 +232,10 @@ def create_river_mesh(river,
     elems = to_quads(river, corr, dilation_width, gid_shift=gid_shift, ax=ax)
 
     # setting river_widths in the river corridor polygon
-    corr = set_width_by_order(river,
+    corr = set_width_by_prop(river,
                               corr,
                               widths=widths,
+                              width_prop = width_prop, 
                               dilation_width=dilation_width,
                               gid_shift=gid_shift)
 
@@ -556,7 +559,7 @@ def to_quads(river, corr, width, gid_shift=0, ax=None):
     return elems
 
 
-def set_width_by_order(river, corr, widths=8, dilation_width=8, gid_shift=0):
+def set_width_by_prop(river, corr, widths=8,  width_prop = 'StreamOrder', dilation_width=8, gid_shift=0):
     """Adjust the river-corridor polygon width by order.
 
     Parameters
@@ -578,18 +581,18 @@ def set_width_by_order(river, corr, widths=8, dilation_width=8, gid_shift=0):
     corr_coords = corr.exterior.coords[:-1]
 
     if type(widths) == dict:
-        stream_order = next(
-            (i for i in ['StreamOrder', 'streamorder', 'streamorde'] if i in river.properties),
-            None)
-        if stream_order is None:
+        prop = next((value for key, value in river.properties.items() if key == width_prop), None)
+
+        if prop is None:
             raise RuntimeError(
-                'set_width_by_order requested widths by stream order, but cannot guess stream order property name'
+                f'set_width_by_prop requested widths by {width_prop} property name, but cannot find this property'
             )
+
 
     for j, node in enumerate(river.preOrder()):
         if type(widths) == dict:
-            order = node.properties[stream_order]
-            target_width = width_by_order(widths, order)
+            prop_value = node.properties[prop]
+            target_width = width_by_prop(widths, prop_value)
         elif callable(widths):
             DA_sqm = node.properties['TotalDrainageAreaSqKm'] * 1e6
             target_width = widths(DA_sqm)
@@ -697,14 +700,17 @@ def move_to_target_separation(p1, p2, target, dilation_width=8):
     return [p1_, p2_]
 
 
-def width_by_order(width_dict, order):
-    """Returns the reach width based using the {order:width dictionary}"""
-    if order > max(width_dict.keys()):
-        width = width_dict[max(width_dict.keys())]
-    elif order < min(width_dict.keys()):
-        width = width_dict[min(width_dict.keys())]
+def width_by_order(width_dict, prop_value):
+    """Returns the reach width based using the {prop:width dictionary}"""
+    if type(prop_value) == int:
+        if prop_value > max(width_dict.keys()):
+            width = width_dict[max(width_dict.keys())]
+        elif prop_value < min(width_dict.keys()):
+            width = width_dict[min(width_dict.keys())]
+        else:
+            width = width_dict[prop_value]
     else:
-        width = width_dict[order]
+        width = width_dict[prop_value]
     return width
 
 
@@ -990,6 +996,7 @@ def adjust_hucs_for_river_corridor(hucs,
             intersection_point = seg.intersection(river_mls)
             if type(intersection_point) is shapely.geometry.Point:
                 parent_node = node_at_intersection(intersection_point, river)
+                print(parent_node.properties['ID'])
 
                 # making sure it is not a leaf node, though this check
                 # fails if there is only one reach in the domain. So

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -6,6 +6,7 @@ import logging
 
 import shapely.geometry
 import shapely.ops
+from scipy.spatial import ConvexHull
 
 import watershed_workflow.utils
 import watershed_workflow.tinytree
@@ -759,7 +760,7 @@ def convexity_enforcement(river, corr, gid_shift):
                     logging.info(
                         f"  could not make these: {points} convex using convex hull, trying nudging...."
                     )
-                    # points = make_convex_by_nudge(points)
+                    points = make_convex_by_nudge(points)
 
                 assert ((watershed_workflow.utils.is_convex(points)))
                 for id, point in zip(elem, points):
@@ -769,15 +770,12 @@ def convexity_enforcement(river, corr, gid_shift):
     return shapely.geometry.Polygon(corr_coords_new)
 
 
-from scipy.spatial import ConvexHull
-
-
 def make_convex_using_hull(points):
+    """Snaps non-convex points to the corresonding edge on the convex hull for the non-convex element"""
     # find points that do not lie on the hull
     hull = ConvexHull(points)
     hull_indices = set(hull.vertices)
     non_hull_points_inds = [i for i in range(len(points)) if i not in hull_indices]
-    # non_hull_points_coordinates = points[non_hull_points_inds]
 
     # for each non-hull point, get the linestring connecting it's preceding point and suceeding point
     hull_edges = []
@@ -796,16 +794,6 @@ def make_convex_using_hull(points):
         points[ind] = nearest_point_on_hull_edge.coords[0]
 
     return points
-
-
-# def make_convex_using_hull(points):
-#     convex_ring = shapely.geometry.Polygon(points).convex_hull.exterior
-#     for i, point in enumerate(points):
-#         # replace point with nearest point on convex hull
-#         p = shapely.geometry.Point(point)
-#         new_point = shapely.ops.nearest_points(convex_ring, p)[0].coords[0]
-#         points[i] = new_point
-#         return points
 
 
 def make_convex_by_nudge(points):

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -20,9 +20,9 @@ def _indexPointInSeg(segment, point, tol=1.e-2):
     try:
         ind = segment.coords[:].index(point.coords[0])
     except ValueError:
-        ind, p = min(((i,p) for (i,p) in enumerate(segment.coords[:])),
-                    key=lambda ip : shapely.geometry.Point(ip[1]).distance(point))
-        assert(shapely.geometry.Point(p).distance(point) < tol)
+        ind, p = min(((i, p) for (i, p) in enumerate(segment.coords[:])),
+                     key=lambda ip: shapely.geometry.Point(ip[1]).distance(point))
+        assert (shapely.geometry.Point(p).distance(point) < tol)
     return ind
 
 
@@ -231,24 +231,18 @@ def create_river_mesh(river,
         dilation_width = min(dilation_width, min(widths.values()))
     elif isinstance(widths, int):
         dilation_width = min(dilation_width, widths)
-  
+
     corr = create_river_corridor(river, dilation_width)
 
     # defining special elements in the mesh
     elems = to_quads(river, corr, dilation_width, gid_shift=gid_shift, ax=ax)
 
     # setting river_widths in the river corridor polygon
-    corr = set_width(river,
-                    corr,
-                    widths=widths,
-                    dilation_width=dilation_width,
-                    gid_shift=gid_shift)
+    corr = set_width(river, corr, widths=widths, dilation_width=dilation_width, gid_shift=gid_shift)
 
     # treating non-convexity at junctions
     if enforce_convexity:
-        corr = convexity_enforcement(river,
-                                     corr,
-                                     gid_shift=gid_shift)
+        corr = convexity_enforcement(river, corr, gid_shift=gid_shift)
 
     # redraw the debug plot with updated elems
     if ax is not None:
@@ -309,7 +303,7 @@ def create_river_corridor(river, width):
 
     # Currently this same for the whole river, should we change it reachwise?
     length_scale = max(2.1 * delta, min(mins) - 8*delta)
-  
+
     logging.info(f"  -- merging points closer than {length_scale} m along the river corridor")
 
     # buffer by the width
@@ -593,7 +587,7 @@ def set_width(river, corr, widths=8, dilation_width=8, gid_shift=0):
             (i for i in ['StreamOrder', 'streamorder', 'streamorde'] if i in river.properties),
             None)
         if stream_order is None:
-             raise RuntimeError(
+            raise RuntimeError(
                 'set_width_by_order requested widths by stream order, but cannot guess stream order property name'
             )
 
@@ -603,14 +597,14 @@ def set_width(river, corr, widths=8, dilation_width=8, gid_shift=0):
             target_width = width_by_order(widths, order)
         elif callable(widths):
             ## DA_sqm = node.properties['TotalDrainageAreaSqKm'] * 1e6
-            # genralized, the above calclations should be done in the function itself 
-            # widths here is a function of node, where 
+            # genralized, the above calclations should be done in the function itself
+            # widths here is a function of node, where
             # widths wil be calculated based on some properties in the node
             target_width = widths(node)
         elif isinstance(widths, bool):
             if widths:
                 target_width = node.properties['width']
-            else: 
+            else:
                 raise RuntimeError('not a valid option to provide width')
         else:
             target_width = widths
@@ -727,7 +721,6 @@ def width_by_order(width_dict, order):
     return width
 
 
-
 def convexity_enforcement(river, corr, gid_shift):
     """Ensure convexity of each river-corridor element.
 
@@ -774,7 +767,10 @@ def convexity_enforcement(river, corr, gid_shift):
     corr_coords_new = coords + [coords[0]]
     return shapely.geometry.Polygon(corr_coords_new)
 
+
 from scipy.spatial import ConvexHull
+
+
 def make_convex_using_hull(points):
     # find points that do not lie on the hull
     hull = ConvexHull(points)
@@ -786,18 +782,20 @@ def make_convex_using_hull(points):
     hull_edges = []
     n = len(points)
     for index in non_hull_points_inds:
-        prev_index = (index - 1) % n
-        next_index = (index + 1) % n
-        
+        prev_index = (index-1) % n
+        next_index = (index+1) % n
+
         edge = (points[prev_index], points[next_index])
         hull_edges.append(shapely.geometry.LineString(edge))
 
-    # for each pair of non-hull point find nearest point on the corresponding hull_edge 
+    # for each pair of non-hull point find nearest point on the corresponding hull_edge
     for ind, hull_edge in zip(non_hull_points_inds, hull_edges):
-        nearest_point_on_hull_edge, _ = shapely.ops.nearest_points(hull_edge, shapely.geometry.Point(points[ind]))
-        points[ind]=nearest_point_on_hull_edge.coords[0]
-    
+        nearest_point_on_hull_edge, _ = shapely.ops.nearest_points(
+            hull_edge, shapely.geometry.Point(points[ind]))
+        points[ind] = nearest_point_on_hull_edge.coords[0]
+
     return points
+
 
 # def make_convex_using_hull(points):
 #     convex_ring = shapely.geometry.Polygon(points).convex_hull.exterior
@@ -807,6 +805,7 @@ def make_convex_using_hull(points):
 #         new_point = shapely.ops.nearest_points(convex_ring, p)[0].coords[0]
 #         points[i] = new_point
 #         return points
+
 
 def make_convex_by_nudge(points):
     """Nudges the neck-points of the junction until the element is convex.
@@ -1038,7 +1037,7 @@ def adjust_hucs_for_river_corridor(hucs,
             intersection_point = seg.intersection(river_mls)
             if type(intersection_point) is shapely.geometry.Point:
                 parent_node = node_at_intersection(intersection_point, river)
-                 # making sure it is not a leaf node, though this check
+                # making sure it is not a leaf node, though this check
                 # fails if there is only one reach in the domain. So
                 # this may fail for a single reach that begins and
                 # ends on the boundary. -- fix me!

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -49,7 +49,8 @@ def _isOverlappingCorridor(corr, river):
         # there is an overlap upstream of the junction of two tributaries,
         # creating a hole
         return 2
-    if not _isExpectedNumPoints(corr, river):
+    n=0
+    if not _isExpectedNumPoints(corr, river, n):
         # overlaps at the junction result in losing points in the corridor polygon.
         return 1
     return 0

--- a/watershed_workflow/river_tree.py
+++ b/watershed_workflow/river_tree.py
@@ -125,8 +125,7 @@ class River(watershed_workflow.tinytree.Tree):
         parent.addChild(new_node)
         return self, new_node
 
-
-    def merge(self, to = 'parent'):
+    def merge(self, to='parent'):
         """Merges this to its parent or to its one and only child."""
         if to == 'parent':
             assert (len(list(self.siblings())) == 0)
@@ -170,7 +169,6 @@ class River(watershed_workflow.tinytree.Tree):
             self.remove()
             for child in self.children:
                 parent.addChild(child)
-
 
     def moveCoordinate(self, i, xy):
         """Moves the ith coordinate of self.segment to a new location."""

--- a/watershed_workflow/river_tree.py
+++ b/watershed_workflow/river_tree.py
@@ -151,6 +151,34 @@ class River(watershed_workflow.tinytree.Tree):
         for child in self.children:
             parent.addChild(child)
 
+    def merge_with_child(self):
+        """Merges this with its one and only child."""
+        assert (len(self.children) == 1)
+
+        # fix properties
+        if 'areasqkm' in self.properties:
+            self.children[0].properties['areasqkm'] += self.properties['areasqkm']
+        if 'AreaSqKm' in self.properties:
+            self.children[0].properties['AreaSqKm'] += self.properties['AreaSqKm']
+        if 'catchment' in self.properties and self.properties['catchment'] is not None:
+            if self.children[0].properties['catchment'] is None:
+                self.children[0].properties['catchment'] = self.properties['catchment']
+            else:
+                self.parent.properties['catchment'] = shapely.ops.unary_union(
+                    [self.properties['catchment'], self.parent.properties['catchment']])
+
+        if 'DivergenceCode' in self.parent.properties:
+            self.children[0].properties['DivergenceCode'] = self.properties['DivergenceCode']
+
+        child = self.children[0]
+        child.moveCoordinate(-1, self.segment.coords[-1])
+
+        parent = self.parent
+        
+        self.remove()
+        for child in self.children:
+            parent.addChild(child)
+
     def moveCoordinate(self, i, xy):
         """Moves the ith coordinate of self.segment to a new location."""
         if i < 0:

--- a/watershed_workflow/sources/manager_nhd.py
+++ b/watershed_workflow/sources/manager_nhd.py
@@ -244,6 +244,11 @@ class _FileManagerNHD:
             reaches = [r for (i, r) in fid.items(bbox=bounds)]
             logging.info(f"  Found total of {len(reaches)} in bounds.")
 
+        ## TEMPORARY FIX ## NHDPlus dataset changed their id name
+        if ('NHDPlusID' not in reaches[0]['properties'].keys()) and ('nhdplusid' in reaches[0]['properties'].keys()):
+            for reach in reaches:
+                reach['properties']['NHDPlusID'] = reach['properties'].pop('nhdplusid')
+
         # filter not in network
         if 'NHDPlus' in self.name and in_network:
             logging.info("  Filtering reaches not in-network")

--- a/watershed_workflow/sources/manager_nhd.py
+++ b/watershed_workflow/sources/manager_nhd.py
@@ -245,15 +245,19 @@ class _FileManagerNHD:
             logging.info(f"  Found total of {len(reaches)} in bounds.")
     
         # check if the dataset is in old NHD Format (title case) or new format (lower case)
-        to_lower = 'nhdplusid' in reaches[0]['properties']
+        to_lower ='nhdplusid' in reaches[0]['properties']
 
         # filter not in network
-        id_key = 'NHDPlusID' if not to_lower else 'nhdplusid'
-        if id_key in self.name and in_network:
+        prop_key = 'InNetwork' if not to_lower else 'innetwork'
+        if 'NHDPlus' in self.name and in_network:
             logging.info("Filtering reaches not in-network")
-            reaches = [r for r in reaches if r['properties'].get('InNetwork' if not to_lower else 'innetwork') == 1]
+            reaches = [
+                r for r in reaches 
+                if prop_key in r['properties'] and r['properties'][prop_key] == 1
+            ]
 
         # associate IDs
+        id_key = 'NHDPlusID' if not to_lower else 'nhdplusid'
         if 'Plus' in self.name and properties is not None:
             for r in reaches:
                 r['properties']['ID'] = str(int(r['properties'][id_key]))

--- a/watershed_workflow/sources/manager_nhd.py
+++ b/watershed_workflow/sources/manager_nhd.py
@@ -244,11 +244,6 @@ class _FileManagerNHD:
             reaches = [r for (i, r) in fid.items(bbox=bounds)]
             logging.info(f"  Found total of {len(reaches)} in bounds.")
 
-        ## TEMPORARY FIX ## NHDPlus dataset changed their id name
-        if ('NHDPlusID' not in reaches[0]['properties'].keys()) and ('nhdplusid' in reaches[0]['properties'].keys()):
-            for reach in reaches:
-                reach['properties']['NHDPlusID'] = reach['properties'].pop('nhdplusid')
-
         # filter not in network
         if 'NHDPlus' in self.name and in_network:
             logging.info("  Filtering reaches not in-network")
@@ -256,6 +251,11 @@ class _FileManagerNHD:
                 r for r in reaches
                 if 'InNetwork' in r['properties'] and r['properties']['InNetwork'] == 1
             ]
+
+        ## TEMPORARY FIX ## NHDPlus dataset changed their id name
+        if ('NHDPlusID' not in reaches[0]['properties'].keys()) and ('nhdplusid' in reaches[0]['properties'].keys()):
+            for reach in reaches:
+                reach['properties']['NHDPlusID'] = reach['properties'].pop('nhdplusid')
 
         # associate IDs
         if 'Plus' in self.name and properties is not None:

--- a/watershed_workflow/sources/manager_nhd.py
+++ b/watershed_workflow/sources/manager_nhd.py
@@ -243,17 +243,16 @@ class _FileManagerNHD:
                 bounds, bounds_crs, watershed_workflow.crs.from_fiona(profile['crs']))
             reaches = [r for (i, r) in fid.items(bbox=bounds)]
             logging.info(f"  Found total of {len(reaches)} in bounds.")
-    
+
         # check if the dataset is in old NHD Format (title case) or new format (lower case)
-        to_lower ='nhdplusid' in reaches[0]['properties']
+        to_lower = 'nhdplusid' in reaches[0]['properties']
 
         # filter not in network
         prop_key = 'InNetwork' if not to_lower else 'innetwork'
         if 'NHDPlus' in self.name and in_network:
             logging.info("Filtering reaches not in-network")
             reaches = [
-                r for r in reaches 
-                if prop_key in r['properties'] and r['properties'][prop_key] == 1
+                r for r in reaches if prop_key in r['properties'] and r['properties'][prop_key] == 1
             ]
 
         # associate IDs

--- a/watershed_workflow/sources/test/test_file_manager_nhdplus.py
+++ b/watershed_workflow/sources/test/test_file_manager_nhdplus.py
@@ -25,23 +25,20 @@ def nhd():
 # having some robustness issues, lets just test a bunch
 def test_nhdplus_url1(nhd):
     url = nhd._url('0204')
-    assert (
-        'https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHDPlusHR/Beta/GDB/NHDPLUS_H_0204_HU4_GDB.zip'
-        == url)
+    assert (url.endswith('_GDB.zip'))
+    assert (url.split('/')[-1].startswith('NHDPLUS_H_0204_HU4'))
 
 
 def test_nhdplus_url2(nhd):
     url = nhd._url('0601')
-    assert (
-        'https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHDPlusHR/Beta/GDB/NHDPLUS_H_0601_HU4_GDB.zip'
-        == url)
+    assert (url.endswith('_GDB.zip'))
+    assert (url.split('/')[-1].startswith('NHDPLUS_H_0601_HU4'))
 
 
 def test_nhdplus_url3(nhd):
     url = nhd._url('1402')
-    assert (
-        'https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHDPlusHR/Beta/GDB/NHDPLUS_H_1402_HU4_GDB.zip'
-        == url)
+    assert (url.endswith('_GDB.zip'))
+    assert (url.split('/')[-1].startswith('NHDPLUS_H_1402_HU4'))
 
 
 def test_nhdplus_url_fail(nhd):
@@ -86,7 +83,7 @@ def test_nhdplus12(nhd):
     # download hydrography
     profile, huc = nhd.get_huc('060102020103')
     profile, rivers = nhd.get_hydro('060102020103')
-    assert (202 == len(rivers))
+    assert (198 == len(rivers))
 
 
 def test_vaa(nhd):

--- a/watershed_workflow/test/test_hilev.py
+++ b/watershed_workflow/test/test_hilev.py
@@ -108,7 +108,7 @@ def test_river_tree_properties(sources_download):
     rivers = watershed_workflow.construct_rivers(reaches, method='hydroseq')
     assert (len(rivers) == 1)
     assert (rivers[0].is_consistent())
-    assert (len(rivers[0]) == 97)
+    assert (len(rivers[0]) == 94)
 
 
 def test_river_tree_properties_prune(sources_download):
@@ -127,7 +127,7 @@ def test_river_tree_properties_prune(sources_download):
                                                  prune_by_area=0.03 * cc.exterior().area * 1.e-6)
     assert (len(rivers) == 1)
     assert (rivers[0].is_consistent())
-    assert (len(rivers[0]) == 50)
+    assert (len(rivers[0]) == 49)
 
 
 def test_river_tree_geometry(sources):

--- a/watershed_workflow/test/test_mesh_mixed.py
+++ b/watershed_workflow/test/test_mesh_mixed.py
@@ -121,7 +121,7 @@ def test_to_quads(river_small, corr_small):
 
 def test_triangulate(watershed_small, river_small):
     points, elems = watershed_workflow.tessalate_river_aligned(watershed_small, [river_small],
-                                                               1,
+                                                               river_width=1,
                                                                tol=0.1,
                                                                refine_min_angle=32,
                                                                refine_distance=[2, 5, 5, 10],

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -100,8 +100,13 @@ class NodesEdges:
         coords = np.array(list(self.nodes))
         kdtree = scipy.spatial.cKDTree(coords)
         bad_pairs = kdtree.query_pairs(tol)
+        
+        # Retrieve the coordinates for each bad pair
+        bad_pair_coords = [(coords[i], coords[j]) for i, j in bad_pairs]
+
         if len(bad_pairs) != 0:
-            raise ValueError('tol= {} is too large, try decrease tolerance!'.format(tol))
+            raise ValueError('tol= {} is too large, try decrease tolerance!'.format(tol)+
+                             'or check bad pairs={}'.format(bad_pair_coords))
 
         min_node = min(self.nodes[n] for n in self.nodes)
         max_node = max(self.nodes[n] for n in self.nodes)

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -160,7 +160,7 @@ def triangulate(hucs,
 
     if internal_boundaries != None:
         if type(internal_boundaries) is list:
-            for item in list:
+            for item in internal_boundaries:
                 if isinstance(item, shapely.geometry.LineString) or isinstance(
                         item, shapely.geometry.Polygon):
                     segments = [item, ] + segments

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -100,13 +100,13 @@ class NodesEdges:
         coords = np.array(list(self.nodes))
         kdtree = scipy.spatial.cKDTree(coords)
         bad_pairs = kdtree.query_pairs(tol)
-        
+
         # Retrieve the coordinates for each bad pair
         bad_pair_coords = [(coords[i], coords[j]) for i, j in bad_pairs]
 
         if len(bad_pairs) != 0:
-            raise ValueError('tol= {} is too large, try decrease tolerance!'.format(tol)+
-                             'or check bad pairs={}'.format(bad_pair_coords))
+            raise ValueError('tol= {} is too large, try decrease tolerance!'.format(tol)
+                             + 'or check bad pairs={}'.format(bad_pair_coords))
 
         min_node = min(self.nodes[n] for n in self.nodes)
         max_node = max(self.nodes[n] for n in self.nodes)
@@ -161,7 +161,8 @@ def triangulate(hucs,
     if internal_boundaries != None:
         if type(internal_boundaries) is list:
             for item in list:
-                if isinstance(item, shapely.geometry.LineString) or isinstance(item, shapely.geometry.Polygon):
+                if isinstance(item, shapely.geometry.LineString) or isinstance(
+                        item, shapely.geometry.Polygon):
                     segments = [item, ] + segments
                 elif isinstance(item, watershed_workflow.river_tree.River):
                     segments = list(item) + segments


### PR DESCRIPTION
This pull request provides improvements to the stream-alined mixed-polyhedral meshing. The main changes include:

- Variable quad lengths: The user can provide different target quad lengths for different reaches. This helps with improving cell aspect ratios for thinner lower-order streams. 
- Widths and Supplemental Depths: Now user can use arbitrary conditions to provide quad widths and supplemental depths. Previously, only dictionaries with stream order as keys or drainage area-based functions were accepted. 
- New densification: Leveraging shapely.LineString-based interpolations while preserving endpoints, the new method yields much more uniform quad lengths compared to the previous method. Currently, the new method is available as `densify_rivers_new`, hopefully in a couple of months, once tested on a range of cases, will become the default. Then we can support the old method as `densify_rivers_old` for reproducibility. 
