### PR TITLE
ssr/discharge regions

### DIFF
--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1179,6 +1179,7 @@ def triangulate(hucs,
                 tol=1,
                 refine_max_area=None,
                 refine_distance=None,
+                refine_polygons = None,
                 refine_max_edge_length=None,
                 refine_min_angle=None,
                 enforce_delaunay=False,
@@ -1215,6 +1216,8 @@ def triangulate(hucs,
         that of the watershed's CRS. The default is 1.
     refine_max_area : float, optional
         Refine a triangle if its area is greater than this area.
+    refine_polygons : [list(shapely.geometry.Polygon), list(float)], optional
+        Refine a triangle if fall within the polygons and its area is greater than the area limit for the polygon
     refine_distance : list(float), optional
         Refine a triangle if its area is greater than a function of its
         centroid's distance from the nearest point on the river network.  The
@@ -1286,6 +1289,8 @@ def triangulate(hucs,
 
     if treat_stream_triangles != None:
         refine_funcs.append(watershed_workflow.triangulation.refine_stream_triangles(river_corrs))
+    if refine_polygons != None:
+        refine_funcs.append(watershed_workflow.triangulation.refine_from_polygons(refine_polygons[0], refine_polygons[1]))
 
     def my_refine_func(*args):
         return any(rf(*args) for rf in refine_funcs)

--- a/watershed_workflow/condition.py
+++ b/watershed_workflow/condition.py
@@ -703,12 +703,13 @@ def _bank_nodes_from_elem(elem, m2):
     longitudinal edges of the river-corridor element.
 
     """
+    
+    assert len(elem) > 3, "elem must not be a triangle element"
     # edge on the right as we look from the downstream direction
     edge_r = list(m2.cell_edges(elem))[0]
 
     # edge on the left as we look from the downstream direction
     edge_l = list(m2.cell_edges(elem))[-2]
-
     return [_bank_nodes_from_edge(edge_r, elem, m2), _bank_nodes_from_edge(edge_l, elem, m2)]
 
 

--- a/watershed_workflow/condition.py
+++ b/watershed_workflow/condition.py
@@ -707,7 +707,7 @@ def _bank_nodes_from_elem(elem, m2):
     edge_r = list(m2.cell_edges(elem))[0]
 
     # edge on the left as we look from the downstream direction
-    edge_l = list(m2.cell_edges(elem))[2]
+    edge_l = list(m2.cell_edges(elem))[-2]
 
     return [_bank_nodes_from_edge(edge_r, elem, m2), _bank_nodes_from_edge(edge_l, elem, m2)]
 

--- a/watershed_workflow/land_cover_properties.py
+++ b/watershed_workflow/land_cover_properties.py
@@ -65,7 +65,7 @@ def computeTimeSeries(lai, lc, unique_lc=None, lc_idx=-1, polygon=None, polygon_
 
     for ilc in unique_lc:
         time_series = [
-            lai.data[itime][mask][np.where(lc.data[lc_idx][mask] == ilc)].mean()
+            np.nanmean(lai.data[itime][mask][np.where(lc.data[lc_idx][mask] == ilc)])
             for itime in range(len(lai.times))
         ]
         col_name = watershed_workflow.sources.manager_modis_appeears.colors[int(ilc)][0]

--- a/watershed_workflow/mesh.py
+++ b/watershed_workflow/mesh.py
@@ -36,8 +36,6 @@ except Exception:
         import exodus3 as exodus
     except Exception:
         exodus = None
-
-
 #
 # A caching decorator, like functools.cache, but works in this case?
 #

--- a/watershed_workflow/regions.py
+++ b/watershed_workflow/regions.py
@@ -221,7 +221,11 @@ def add_watershed_regions_and_outlets(m2,
 def add_discharge_regions(m2, discharge_points, labels=None, include_cells=True, buffer_width=1):
     """Add labeled sets for three faces for each discharge point in the river corridor.
     The three faces include downstream shorter edge of the quad and two edges connecting 
-    two downstream vertices of the quad and non-quad vertice on the bank triangle.
+    two downstream vertices of the quad and non-quad vertice on the bank triangle. 
+    Corresponding upstreams cells (a quad and two triangles) are also added if include_cells is True,
+    which should be use with 
+    <Parameter name="direction normalized flux relative to region" type="string" value="discharge_cell_region_name" />
+    in the ATS observation parameter list in the input file 
 
     Parameters
     ----------
@@ -232,6 +236,10 @@ def add_discharge_regions(m2, discharge_points, labels=None, include_cells=True,
     labels : list of str, optional
         Custom labels for each discharge point. If not provided, defaults to
         'discharge point 0', 'discharge point 1', etc.
+    include_cells : bool, optional
+        If True, add a labeled set for the cells just upstream of discharge faces. Default is True.
+    buffer_width : float, optional
+        Buffer width to identify quad elements containing the discharge point. Default is 1.
 
     Notes
     -----
@@ -239,6 +247,9 @@ def add_discharge_regions(m2, discharge_points, labels=None, include_cells=True,
     1. The downstream edge of the quad element containing the point
     2. Edge connecting downstream right vertex to right bank
     3. Edge connecting downstream left vertex to left bank
+    and labeled set containing three cells:
+    1. the quad element containing the point
+    2. the two triangles sharing edges with the quad
     """
     if labels is None:
         labels = ['discharge region ' + str(i) for i in range(len(discharge_points))]
@@ -278,12 +289,16 @@ def find_discharge_edges_cells(m2, discharge_point, include_cells=True, buffer_w
         The 2D mesh containing river corridor elements
     discharge_point : shapely.geometry.Point
         The discharge point location
+    include_cells : bool, optional
+        If True, include cells in the labeled set. Default is True.
+    buffer_width : float, optional
+        Buffer width to identify quad elements containing the discharge point. Default is 1.
 
     Returns
     -------
     list of tuples
-        List of (vertex1, vertex2) pairs defining edges around the discharge point.
-        Returns empty list if discharge point not found in mesh.
+        List of (vertex1, vertex2) pairs defining edges.
+        if include_cells is True, also returns the cells just upstream of the edges.
     """
     # find the quad element that contains the discharge point
     discharge_quad = None

--- a/watershed_workflow/regions.py
+++ b/watershed_workflow/regions.py
@@ -257,6 +257,8 @@ def add_discharge_regions(m2, discharge_points, labels=None, buffer_width=1):
                                                      m2.next_available_labeled_setid(), 'FACE', discharge_edges)
             ls2.to_extrude = True
             m2.labeled_sets.append(ls2)
+        else:
+            print(f"No discharge edges found for point {discharge_point}")
 
 
 def find_discharge_edges(m2, discharge_point, buffer_width=1):

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -88,7 +88,7 @@ class FileManagerMODISAppEEARS:
     _BUNDLE_URL_TEMPLATE = "https://appeears.earthdatacloud.nasa.gov/api/bundle/{0}"
 
     _START = datetime.date(2002, 7, 1)
-    _END = datetime.date(2021, 1, 1)
+    _END = datetime.date(2024, 1, 1)
 
     _PRODUCTS = {
         'LAI': {

--- a/watershed_workflow/split_hucs.py
+++ b/watershed_workflow/split_hucs.py
@@ -385,8 +385,6 @@ def intersectAndSplit(list_of_shapes):
                     left_over_polys = []
                     for poly in parts_polys:
                         mps = poly.intersection(mls)
-
-                        # print(mps)
                         assert (isinstance(mps, shapely.geometry.MultiPoint))
                         assert (len(mps) == 2)
                         parts_lines.append(


### PR DESCRIPTION
**Major update:**

- **Add three-face discharge regions** 

Add labeled sets for three faces for each discharge point in the river corridor. The three faces include downstream shorter edge of the quad and two edges connecting two downstream vertices of the quad and non-quad vertice on the bank triangle. Corresponding upstreams cells (a quad and two triangles) are also added for <Parameter name="direction normalized flux relative to region" type="string" value="discharge_cell_region_name" /> in the ATS observation parameter list in the input file 

- **Refinement based on polygons** 
 Returns a graded refinement function based upon polygon area limits, for use with Triangle. Triangle area must be smaller than the area limit for the polygon when the triangle centroid is within the polygon

**Minor updates:**
- fix for nan values in LAI
- modis manager end date set to (2024, 1, 1)