### PR TITLE
Updates supporting flux-recording at large number of locations along river corridor; other minor bug-fixes 

### DIFF
--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1173,7 +1173,7 @@ def triangulate(hucs,
                 internal_boundaries=None,
                 treat_stream_triangles=None,
                 hole_points=None,
-                additional_points=None,  
+                additional_points=None,
                 diagnostics=True,
                 verbosity=1,
                 tol=1,
@@ -1283,7 +1283,7 @@ def triangulate(hucs,
     if refine_max_edge_length != None:
         refine_funcs.append(
             watershed_workflow.triangulation.refine_from_max_edge_length(refine_max_edge_length))
-        
+
     if treat_stream_triangles != None:
         refine_funcs.append(watershed_workflow.triangulation.refine_stream_triangles(river_corrs))
 
@@ -1295,26 +1295,32 @@ def triangulate(hucs,
         river_corrs,
         internal_boundaries=internal_boundaries,
         hole_points=hole_points,
-        additional_points=additional_points, 
+        additional_points=additional_points,
         tol=tol,
         verbose=verbose,
         refinement_func=my_refine_func,
         min_angle=refine_min_angle,
         enforce_delaunay=enforce_delaunay,
         allow_boundary_steiner=(river_corrs is None))
-        
-    if river_corrs != None: # stream-aligned mesh
+
+    if river_corrs != None:  # stream-aligned mesh
         stream_triangles = identify_stream_triangles(vertices, triangles, river_corrs)
         if treat_stream_triangles == None:
-            logging.warning(f'Found {len(stream_triangles)} stream triangles - consider using "treat_stream_triangles" option')
+            logging.warning(
+                f'Found {len(stream_triangles)} stream triangles - consider using "treat_stream_triangles" option'
+            )
         elif treat_stream_triangles == 'moderate':
-            logging.warning(f'{len(stream_triangles)} stream triangles could not be refined - consider using treat_stream_triangles="strict"')
+            logging.warning(
+                f'{len(stream_triangles)} stream triangles could not be refined - consider using treat_stream_triangles="strict"'
+            )
         elif treat_stream_triangles == 'strict':
             if additional_points is None:
-                additional_points = watershed_workflow.river_mesh.triangle_split_points(stream_triangles, river_corrs)
+                additional_points = watershed_workflow.river_mesh.triangle_split_points(
+                    stream_triangles, river_corrs)
             else:
-                additional_points = additional_points + watershed_workflow.river_mesh.triangle_split_points(stream_triangles, river_corrs)
-            
+                additional_points = additional_points + watershed_workflow.river_mesh.triangle_split_points(
+                    stream_triangles, river_corrs)
+
             # triangulate again with additional points to split stream triangles
             logging.info('triangulating again with additional points to split stream triangles')
             vertices, triangles = watershed_workflow.triangulation.triangulate(
@@ -1322,24 +1328,25 @@ def triangulate(hucs,
                 river_corrs,
                 internal_boundaries=internal_boundaries,
                 hole_points=hole_points,
-                additional_points=additional_points, 
+                additional_points=additional_points,
                 tol=tol,
                 verbose=verbose,
                 refinement_func=my_refine_func,
                 min_angle=refine_min_angle,
                 enforce_delaunay=enforce_delaunay,
                 allow_boundary_steiner=(river_corrs is None))
-                
+
             stream_triangles = identify_stream_triangles(vertices, triangles, river_corrs)
             if len(stream_triangles) > 0:
-                logging.info('Found %d stream triangles that could not be split:', len(stream_triangles))
+                logging.info('Found %d stream triangles that could not be split:',
+                             len(stream_triangles))
                 for i, tri in enumerate(stream_triangles):
                     logging.info('  Triangle %d coordinates:', i)
                     for j, vertex in enumerate(tri):
                         logging.info('    Vertex %d: (%.2f, %.2f)', j, vertex[0], vertex[1])
             else:
                 logging.info('all stream triangles treated')
-        
+
     if diagnostics or river_region_dist is not None:
         logging.info("Plotting triangulation diagnostics")
         river_multiline = shapely.geometry.MultiLineString([r for river in rivers for r in river])
@@ -1403,7 +1410,7 @@ def tessalate_river_aligned(hucs,
                             internal_boundaries=None,
                             hole_points=None,
                             treat_stream_triangles=None,
-                            additional_points=None,  
+                            additional_points=None,
                             diagnostics=False,
                             ax=None,
                             **kwargs):
@@ -1464,7 +1471,7 @@ def tessalate_river_aligned(hucs,
                                                                           enforce_convexity=True,
                                                                           ax=ax,
                                                                           label=False)
-    
+
     # adjust the HUC to match the corridor at the boundary
     logging.info('Adjusting rivers at the watershed boundaries...')
     hucs_without_outlet = hucs.deep_copy()
@@ -1474,10 +1481,10 @@ def tessalate_river_aligned(hucs,
                                                                   integrate_rc=False,
                                                                   ax=ax)
 
-     # triangulate the rest
-    tri_res = watershed_workflow.triangulate(hucs_without_outlet, rivers, corrs, 
-                                             internal_boundaries, treat_stream_triangles, hole_points, additional_points, 
-                                             diagnostics, **kwargs)
+    # triangulate the rest
+    tri_res = watershed_workflow.triangulate(hucs_without_outlet, rivers, corrs,
+                                             internal_boundaries, treat_stream_triangles,
+                                             hole_points, additional_points, diagnostics, **kwargs)
     tri_verts = tri_res[0]
     tri_conn = tri_res[1]
 
@@ -1747,6 +1754,8 @@ def identify_stream_triangles(vertices, triangles, river_corrs, buffer_distance=
     for tri in triangles:
         tri_verts = vertices[tri]
         points = [shapely.geometry.Point(v[0], v[1]) for v in tri_verts]
-        if all(any(corridor.intersects(point.buffer(buffer_distance)) for corridor in river_corrs) for point in points):
+        if all(
+                any(corridor.intersects(point.buffer(buffer_distance)) for corridor in river_corrs)
+                for point in points):
             stream_triangles.append(tri_verts)
     return stream_triangles

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -819,6 +819,7 @@ def construct_rivers(reaches,
                      area_property='DivergenceRoutedDrainAreaSqKm',
                      remove_diversions=False,
                      remove_braided_divergences=False,
+                     preserve_catchments=False,
                      tol=0.1):
     """Create a river, which is a tree of reaches.
     
@@ -856,6 +857,8 @@ def construct_rivers(reaches,
     remove_braided_divergences : bool, optional=False
         If true, remove braided divergences (see documentation of
         modify_rivers_remove_divergences()).
+    preserve_catchments : bool, optional=False
+        If true, accumulate catchments of pruned reaches into parent reaches. Default is False.
     tol : float, optional=0.1
         Defines what close is in the case of method == 'geometry'
 
@@ -874,7 +877,7 @@ def construct_rivers(reaches,
     logging.info(f" ... generated {len(rivers)} rivers")
 
     return reduce_rivers(rivers, ignore_small_rivers, prune_by_area, area_property,
-                         remove_diversions, remove_braided_divergences, tol)
+                         remove_diversions, remove_braided_divergences, preserve_catchments, tol)
 
 
 def reduce_rivers(rivers,
@@ -883,6 +886,7 @@ def reduce_rivers(rivers,
                   area_property='DivergenceRoutedDrainAreaSqKm',
                   remove_diversions=False,
                   remove_braided_divergences=False,
+                  preserve_catchments=False,
                   tol=0.1):
     """Create a river, which is a tree of reaches.
     
@@ -910,6 +914,8 @@ def reduce_rivers(rivers,
     remove_braided_divergences : bool, optional=False
         If true, remove braided divergences (see documentation of
         modify_rivers_remove_divergences()).
+    preserve_catchments : bool, optional=False
+        If true, accumulate catchments of pruned reaches into parent reaches. Default is False.
     tol : float, optional=0.1
         Defines what close is in the case of method == 'geometry'
 
@@ -945,7 +951,7 @@ def reduce_rivers(rivers,
         return rivers
 
     if prune_by_area is not None:
-        rivers = watershed_workflow.hydrography.pruneByArea(rivers, prune_by_area, area_property)
+        rivers = watershed_workflow.hydrography.pruneByArea(rivers, prune_by_area, area_property, preserve_catchments)
 
     if ignore_small_rivers > 0:
         rivers = watershed_workflow.hydrography.filterSmallRivers(rivers, ignore_small_rivers)

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1751,11 +1751,9 @@ def identify_stream_triangles(vertices, triangles, river_corrs, buffer_distance=
         List of vertex arrays for triangles that are fully within river corridors
     """
     stream_triangles = []
+    riv_corr = shapely.ops.unary_union(river_corrs).buffer(1)
     for tri in triangles:
         tri_verts = vertices[tri]
-        points = [shapely.geometry.Point(v[0], v[1]) for v in tri_verts]
-        if all(
-                any(corridor.intersects(point.buffer(buffer_distance)) for corridor in river_corrs)
-                for point in points):
+        if all(riv_corr.intersects(shapely.geometry.Point(p)) for p in tri_verts):
             stream_triangles.append(tri_verts)
     return stream_triangles

--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -1179,6 +1179,7 @@ def triangulate(hucs,
                 tol=1,
                 refine_max_area=None,
                 refine_distance=None,
+                refine_polygons = None,
                 refine_max_edge_length=None,
                 refine_min_angle=None,
                 enforce_delaunay=False,
@@ -1215,6 +1216,8 @@ def triangulate(hucs,
         that of the watershed's CRS. The default is 1.
     refine_max_area : float, optional
         Refine a triangle if its area is greater than this area.
+    refine_polygons : [list(shapely.geometry.Polygon), list(float)], optional
+        Refine a triangle if fall within the polygons and its area is greater than the area limit for the polygon
     refine_distance : list(float), optional
         Refine a triangle if its area is greater than a function of its
         centroid's distance from the nearest point on the river network.  The
@@ -1286,6 +1289,8 @@ def triangulate(hucs,
 
     if treat_stream_triangles != None:
         refine_funcs.append(watershed_workflow.triangulation.refine_stream_triangles(river_corrs))
+    if refine_polygons != None:
+        refine_funcs.append(watershed_workflow.triangulation.refine_from_polygons(refine_polygons[0], refine_polygons[1]))
 
     def my_refine_func(*args):
         return any(rf(*args) for rf in refine_funcs)

--- a/watershed_workflow/condition.py
+++ b/watershed_workflow/condition.py
@@ -703,12 +703,13 @@ def _bank_nodes_from_elem(elem, m2):
     longitudinal edges of the river-corridor element.
 
     """
+    
+    assert len(elem) > 3, "elem must not be a triangle element"
     # edge on the right as we look from the downstream direction
     edge_r = list(m2.cell_edges(elem))[0]
 
     # edge on the left as we look from the downstream direction
-    edge_l = list(m2.cell_edges(elem))[2]
-
+    edge_l = list(m2.cell_edges(elem))[-2]
     return [_bank_nodes_from_edge(edge_r, elem, m2), _bank_nodes_from_edge(edge_l, elem, m2)]
 
 

--- a/watershed_workflow/condition.py
+++ b/watershed_workflow/condition.py
@@ -581,7 +581,7 @@ def condition_river_mesh(m2,
             # this to ensure that a diked channel passing over/around
             # a pond or reservoirs does not have bank-nodes fall into
             # the depression
-            if treat_banks:
+            if treat_banks and len(elem)>3:
                 bank_node_ids = _bank_nodes_from_elem(elem, m2)
                 for node_id in bank_node_ids:
                     if node_id not in river_corr_ids:

--- a/watershed_workflow/land_cover_properties.py
+++ b/watershed_workflow/land_cover_properties.py
@@ -65,7 +65,7 @@ def computeTimeSeries(lai, lc, unique_lc=None, lc_idx=-1, polygon=None, polygon_
 
     for ilc in unique_lc:
         time_series = [
-            lai.data[itime][mask][np.where(lc.data[lc_idx][mask] == ilc)].mean()
+            np.nanmean(lai.data[itime][mask][np.where(lc.data[lc_idx][mask] == ilc)])
             for itime in range(len(lai.times))
         ]
         col_name = watershed_workflow.sources.manager_modis_appeears.colors[int(ilc)][0]

--- a/watershed_workflow/mesh.py
+++ b/watershed_workflow/mesh.py
@@ -36,8 +36,6 @@ except Exception:
         import exodus3 as exodus
     except Exception:
         exodus = None
-
-
 #
 # A caching decorator, like functools.cache, but works in this case?
 #

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -1193,59 +1193,30 @@ def triangle_split_points(stream_triangles, river_corrs):
     river_corrs : list of shapely.geometry.Polygon
         List of river corridor polygons.
     """
+    river_corr = shapely.ops.unary_union(river_corrs).buffer(1)
     additional_points = []
+
     for tri_verts in stream_triangles:
+        assert len(tri_verts) == 3
+
         # Get midpoints of each edge
         midpoints = [
-            watershed_workflow.utils.midpoint(tri_verts[0], tri_verts[1]),
-            watershed_workflow.utils.midpoint(tri_verts[1], tri_verts[2]), 
-            watershed_workflow.utils.midpoint(tri_verts[2], tri_verts[0])
+            shapely.geometry.Point(
+                watershed_workflow.utils.midpoint(tri_verts[i], tri_verts[(i+1) % 3]))
+            for i in range(3)
         ]
-        
+
         # Check which midpoints lie on river corridors
-        on_corridor = []
-        off_corridor = []
-        for i, mp in enumerate(midpoints):
-            point = shapely.geometry.Point(mp)
-            if any(corridor.intersects(point.buffer(1)) for corridor in river_corrs):
-                on_corridor.append((i, mp))
-            else:
-                off_corridor.append((i, mp))
-        
+        off_corridor = list(
+            filter(lambda ip: not river_corr.intersects(ip[1]), enumerate(midpoints)))
+
         # We expect exactly one midpoint to be off the corridor
-        if len(off_corridor) == 1:
-            off_edge_idx = off_corridor[0][0]
-            if off_edge_idx == 0:
-                center_point = tri_verts[2]
-                off_corridor_seg = shapely.geometry.LineString([tri_verts[0], tri_verts[1]])
-            elif off_edge_idx == 1:
-                center_point = tri_verts[0]
-                off_corridor_seg = shapely.geometry.LineString([tri_verts[1], tri_verts[2]])
-            else:  # off_edge_idx == 2
-                center_point = tri_verts[1]
-                off_corridor_seg = shapely.geometry.LineString([tri_verts[0], tri_verts[2]])
-            
-            # Find the additional point
-            additional_point = find_additional_point(off_corridor_seg, center_point, extension_factor=1)
-            additional_points.append(additional_point.coords[0])
+        assert len(off_corridor) == 1
+        edge_i = off_corridor[0][0]
+
+        # Find the additional point
+        edge_midpoint = watershed_workflow.utils.midpoint(tri_verts[edge_i],
+                                                          tri_verts[(edge_i+1) % 3])
+        additional_points.append(edge_midpoint)
 
     return additional_points
-
-
-def find_additional_point(off_corridor_seg, center_point, extension_factor=1):
-    """Find an additional point on a common segment between a triangle and a river corridor.
-    
-    Parameters
-    ----------
-    off_corridor_seg : shapely.geometry.LineString
-        Triangle edge that is not on the river corridor.
-    center_point : tuple
-        Common vertex of on-corridor triangle edges.
-    extension_factor : float, optional
-        The factor by which to extend the vector from the center point to the midpoint of the off-corridor edge of the triangle.
-    """
-    mid_point = off_corridor_seg.interpolate(0.5, normalized=True)
-    vector = np.array(mid_point.coords[0]) - np.array(center_point)
-    extended_vector = vector * extension_factor
-    additional_point = shapely.geometry.Point(np.array(center_point) + extended_vector)
-    return additional_point

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -1205,18 +1205,30 @@ def triangle_split_points(stream_triangles, river_corrs):
                 watershed_workflow.utils.midpoint(tri_verts[i], tri_verts[(i+1) % 3]))
             for i in range(3)
         ]
-
+        
         # Check which midpoints lie on river corridors
         off_corridor = list(
             filter(lambda ip: not river_corr.intersects(ip[1]), enumerate(midpoints)))
 
-        # We expect exactly one midpoint to be off the corridor
         if len(off_corridor) == 1:
             edge_i = off_corridor[0][0]
-
-            # Find the additional point
             edge_midpoint = watershed_workflow.utils.midpoint(tri_verts[edge_i],
                                                               tri_verts[(edge_i+1) % 3])
             additional_points.append(edge_midpoint)
-
-    return additional_points
+                
+        elif len(off_corridor) == 2:
+            edge_lengths = [
+                watershed_workflow.utils.distance(tri_verts[off_corridor[i][0]], 
+                                                    tri_verts[(off_corridor[i][0]+1) % 3])
+                for i in range(2)
+            ]          
+            # Select the midpoint on the longer edge
+            longer_edge_index = edge_lengths.index(max(edge_lengths))
+            edge_i = off_corridor[longer_edge_index][0]
+            edge_midpoint = watershed_workflow.utils.midpoint(tri_verts[edge_i],
+                                                                tri_verts[(edge_i+1) % 3])
+            additional_points.append(edge_midpoint)
+     
+    # Remove coinciding points
+    unique_points = list(set(additional_points))
+    return unique_points

--- a/watershed_workflow/river_mesh.py
+++ b/watershed_workflow/river_mesh.py
@@ -1211,12 +1211,12 @@ def triangle_split_points(stream_triangles, river_corrs):
             filter(lambda ip: not river_corr.intersects(ip[1]), enumerate(midpoints)))
 
         # We expect exactly one midpoint to be off the corridor
-        assert len(off_corridor) == 1
-        edge_i = off_corridor[0][0]
+        if len(off_corridor) == 1:
+            edge_i = off_corridor[0][0]
 
-        # Find the additional point
-        edge_midpoint = watershed_workflow.utils.midpoint(tri_verts[edge_i],
-                                                          tri_verts[(edge_i+1) % 3])
-        additional_points.append(edge_midpoint)
+            # Find the additional point
+            edge_midpoint = watershed_workflow.utils.midpoint(tri_verts[edge_i],
+                                                              tri_verts[(edge_i+1) % 3])
+            additional_points.append(edge_midpoint)
 
     return additional_points

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -88,7 +88,7 @@ class FileManagerMODISAppEEARS:
     _BUNDLE_URL_TEMPLATE = "https://appeears.earthdatacloud.nasa.gov/api/bundle/{0}"
 
     _START = datetime.date(2002, 7, 1)
-    _END = datetime.date(2021, 1, 1)
+    _END = datetime.date(2024, 1, 1)
 
     _PRODUCTS = {
         'LAI': {

--- a/watershed_workflow/split_hucs.py
+++ b/watershed_workflow/split_hucs.py
@@ -385,8 +385,6 @@ def intersectAndSplit(list_of_shapes):
                     left_over_polys = []
                     for poly in parts_polys:
                         mps = poly.intersection(mls)
-
-                        # print(mps)
                         assert (isinstance(mps, shapely.geometry.MultiPoint))
                         assert (len(mps) == 2)
                         parts_lines.append(

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -123,7 +123,7 @@ def triangulate(hucs,
                 river_corrs=None,
                 internal_boundaries=None,
                 hole_points=None,
-                additional_points=None,  
+                additional_points=None,
                 tol=1,
                 **kwargs):
     """Triangulates HUCs and rivers.
@@ -234,8 +234,7 @@ def triangulate(hucs,
 
     mesh_points = np.array(mesh.points)
     mesh_tris = np.array(mesh.elements)
-    
-     
+
     logging.info("  ...built: %i mesh points and %i triangles" % (len(mesh_points), len(mesh_tris)))
     return mesh_points, mesh_tris
 
@@ -309,8 +308,10 @@ def refine_from_max_edge_length(edge_length):
 def refine_stream_triangles(river_corrs):
     """Returns a refinement function for triangles that have all three vertices on stream mesh."""
     riv_corr = shapely.ops.unary_union(river_corrs).buffer(1)
+
     def refine(vertices, area):
         return all(riv_corr.intersects(shapely.geometry.Point(p)) for p in vertices)
+
     return refine
 
 


### PR DESCRIPTION
**Major Updates**

- **Treat Triangles Embedded in the Stream Mesh**

Triangles with all three vertices on the stream mesh can cause issues for applications like stream network connectivity. They often can divert water from corridor through them and act like a braid. To deal with this a two-stage treatment is implemented, with user options to select the level of treatment. These options can be accessed through a optional flag `treat_stream_triangles : {'None', 'moderate', 'strict'}` in `tessalate_river_aligned` function:

- `moderate`: This will deploy refinement function of the `triangle` library, where stream triangles are identified and passed on for additional refinement. This can take of most of the triangles, however, it is not an strict enforcement as triangulation algorithm will try to balance between multiple constraints and refinement like angles and cell sizes. 
- `strict`: This method will split the stream triangles that could not be refined with the `moderate` option, by providing additional point (mid point of the off-river-corridor edge) during triangulation.

See image below where a stream triangle was split; red markers depicts the original stream triangle. 

<img width="523" alt="stream_triangle_treatment" src="https://github.com/user-attachments/assets/ac19ffbe-b4bf-4c50-b304-57253effa96f">


- **Add three-face discharge regions** 

Add labeled sets for three faces for each discharge point in the river corridor. The three faces include downstream shorter edge of the quad and two edges connecting two downstream vertices of the quad and non-quad vertice on the bank triangle. Corresponding upstreams cells (a quad and two triangles) are also added for `<Parameter name="direction normalized flux relative to region" type="string" value="discharge_cell_region_name" />` in the ATS observation parameter list in the input file 

- **Refinement based on polygons** 
 Returns a graded refinement function based upon polygon area limits, for use with Triangle. Triangle area must be smaller than the area limit for the polygon when the triangle centroid is within the polygon

**Minor updates:**
- fix for nan values in LAI
- modis manager end date set to (2024, 1, 1)
- bug-fix in "bank integrity" step in hydro-conditioning of river corridor 
- preserve catchment option made available in higher level functions like `construct_river`