### PR TITLE
New logic for env and main CI tasks and docker images

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -6,6 +6,8 @@ name: CI Environment to Docker Hub
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  pull_request: 
+    branches: [ master, geopandas_xarray ]
 
 jobs:
   build:

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -35,13 +35,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}      
-
+ 
       - name: Get runner architecture
         run: |
           if [[ ${{matrix.os}} == "ubuntu-24.04-arm" ]]; then
@@ -49,6 +43,12 @@ jobs:
           else
             echo "ARCH=amd64" >> $GITHUB_ENV
           fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}     
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,15 +54,27 @@ jobs:
           else
             echo "ARCH=amd64" >> $GITHUB_ENV
           fi
+      - name: Check to see if CI_ENV_DOCKER_TAG exists for current branch
+        run: |
+          # check to see if manifest for requested image exists, echo $? returns 0 if it exists 
+          docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest > /dev/null ;
+          # returns 0 if image exists, 1 if it is missing (so default to master if 1)
+          if echo $?; then
+            echo "CI_ENV_BRANCH=master" >> $GITHUB_ENV
+          else
+            echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}" >> $GITHUB_ENV
+          fi 
+          # verify that logic above has worked
+          echo ${{env.CI_ENV_BRANCH}}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./docker/CI.Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci:${{ env.BRANCH_TAG }}-${{ env.ARCH }}
-          build-args: CI_ENV_DOCKER_TAG=master
+          build-args: CI_ENV_DOCKER_TAG=${{env.CI_ENV_BRANCH}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,12 +41,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}      
+      
       - name: Get runner architecture
         run: |
           if [[ ${{matrix.os}} == "ubuntu-24.04-arm" ]]; then
@@ -54,6 +49,7 @@ jobs:
           else
             echo "ARCH=amd64" >> $GITHUB_ENV
           fi
+
       - name: Check to see if CI_ENV_DOCKER_TAG exists for current branch
         run: |
           # check to see if manifest for requested image exists, echo $? returns 0 if it exists 
@@ -66,6 +62,13 @@ jobs:
           fi 
           # verify that logic above has worked
           echo ${{env.CI_ENV_BRANCH}}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6


### PR DESCRIPTION
1. runs env.yml task on PR to master and geopandas_xarray
2. main.yml searches for a ci-env image on dockerhub, or defaults to master tag if it is not there.

Note because of the multiarch changes, the env.yml task will have to run once on each branch
before the main task. Might be worth running these in a single CI task, but where the env steps only
run if there are changes to certain files in the
repository (similar to how Amanzi-ATS TPLs are handled now in amanzi/amanzi)