### PR TITLE
Update CI for new environments, packages

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -47,7 +47,7 @@ jobs:
           context: ./
           file: ./docker/CI-Env.Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_HUB_USERNAME}}
-          password: ${{secrets.DOCKER_HUB_PASSWORD}}
+          password: ${{secrets.DOCKER_HUB_ACCESS_TOKEN}}
       - name: Pull images (remove with artifacts??)
         run: |
           docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -83,7 +83,7 @@ jobs:
           password: ${{secrets.DOCKER_HUB_ACCESS_TOKEN}}
       - name: Pull images (remove with artifacts??)
         run: |
-          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64-latest
+          docker pull --platform=linux/arm64 ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64-latest
           docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-amd64-latest
       - name: Edit manifest
         run: |

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -57,7 +57,7 @@ jobs:
           context: ./
           file: ./docker/CI-Env.Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-${{ env.ARCH }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-${{ env.ARCH }}-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           
@@ -83,8 +83,8 @@ jobs:
           password: ${{secrets.DOCKER_HUB_ACCESS_TOKEN}}
       - name: Pull images (remove with artifacts??)
         run: |
-          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64
-          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-amd64
+          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64-latest
+          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-amd64-latest
       - name: Edit manifest
         run: |
           docker manifest create ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest \

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -11,12 +11,7 @@ on:
 
 jobs:
   build:
-    # The type of runner that the job will run on
-    strategy:
-      fail-fast: false 
-      matrix: 
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -32,17 +27,12 @@ jobs:
         id: extract_tag
         run: echo "BRANCH_TAG=$(echo ${GITHUB_REF_NAME} | sed 's/[^[:alnum:]\.\_\-]/-/g')" >> $GITHUB_ENV
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
- 
-      - name: Get runner architecture
-        run: |
-          if [[ ${{matrix.os}} == "ubuntu-24.04-arm" ]]; then
-            echo "ARCH=arm64" >> $GITHUB_ENV
-          else
-            echo "ARCH=amd64" >> $GITHUB_ENV
-          fi
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -57,38 +47,10 @@ jobs:
           context: ./
           file: ./docker/CI-Env.Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-${{ env.ARCH }}-latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-  fix-manifest:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4     
-      - name: Extract branch name
-        id: extract_branch
-        run: echo "BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
-      - name: Extract docker tag name
-        id: extract_tag
-        run: echo "BRANCH_TAG=$(echo ${GITHUB_REF_NAME} | sed 's/[^[:alnum:]\.\_\-]/-/g')" >> $GITHUB_ENV
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{secrets.DOCKER_HUB_USERNAME}}
-          password: ${{secrets.DOCKER_HUB_ACCESS_TOKEN}}
-      - name: Pull images (remove with artifacts??)
-        run: |
-          docker pull --platform=linux/arm64 ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64-latest
-          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-amd64-latest
-      - name: Edit manifest
-        run: |
-          docker manifest create ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest \
-            --amend ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-arm64-latest \
-            --amend ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-amd64-latest
-          docker manifest push ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,12 @@ jobs:
       - name: Check to see if CI_ENV_DOCKER_TAG exists for current branch
         run: |
           # check to see if manifest for requested image exists, echo $? returns 0 if it exists 
-          docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest > /dev/null 2>&1 ;
+          docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }} > /dev/null 2>&1 ;
           # returns 0 if image exists, 1 if it is missing (so default to master if 1)
           if [ $? -eq 1 ]; then
             echo "CI_ENV_BRANCH=master" >> $GITHUB_ENV
           else
-            echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}-latest" >> $GITHUB_ENV
+            echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}" >> $GITHUB_ENV
           fi 
 
       - name: check environment variable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           # check to see if manifest for requested image exists, echo $? returns 0 if it exists 
           docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest > /dev/null 2>&1 ;
           # returns 0 if image exists, 1 if it is missing (so default to master if 1)
-          if echo $?; then
+          if [ $? -eq 1 ]; then
             echo "CI_ENV_BRANCH=master" >> $GITHUB_ENV
           else
             echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,13 +53,16 @@ jobs:
       - name: Check to see if CI_ENV_DOCKER_TAG exists for current branch
         run: |
           # check to see if manifest for requested image exists, echo $? returns 0 if it exists 
-          docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest > /dev/null ;
+          docker manifest inspect ${{secrets.DOCKER_HUB_USERNAME}}/watershed_workflow-ci_env:${{ env.BRANCH_TAG }}-latest > /dev/null 2>&1 ;
           # returns 0 if image exists, 1 if it is missing (so default to master if 1)
           if echo $?; then
             echo "CI_ENV_BRANCH=master" >> $GITHUB_ENV
           else
             echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}" >> $GITHUB_ENV
           fi 
+
+      - name: check environment variable
+        run: |
           # verify that logic above has worked
           echo ${{env.CI_ENV_BRANCH}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           if [ $? -eq 1 ]; then
             echo "CI_ENV_BRANCH=master" >> $GITHUB_ENV
           else
-            echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}" >> $GITHUB_ENV
+            echo "CI_ENV_BRANCH=${{env.BRANCH_TAG}}-latest" >> $GITHUB_ENV
           fi 
 
       - name: check environment variable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_HUB_USERNAME}}
-          password: ${{secrets.DOCKER_HUB_PASSWORD}}
+          password: ${{secrets.DOCKER_HUB_ACCESS_TOKEN}}
       - name: Pull images (remove with artifacts??)
         run: |
           docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/watershed_workflow-ci:${{ env.BRANCH_TAG }}-arm64

--- a/docker/CI-Env-FromFile.Dockerfile
+++ b/docker/CI-Env-FromFile.Dockerfile
@@ -21,7 +21,7 @@ RUN ${CONDA_BIN} env create -f /ww/tmp/environments/environment-CI-Linux.yml
 
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     /opt/conda/bin/python create_envs.py --manager=${CONDA_BIN} --without-ww-env \
-        --with-tools-env --tools-env-name=watershed_workflow_tools Linux
+        --with-tools-env=watershed_workflow_tools Linux
 
 #
 # Stage 2 -- add in the pip

--- a/docker/CI-Env.Dockerfile
+++ b/docker/CI-Env.Dockerfile
@@ -16,8 +16,8 @@ RUN mkdir environments
 RUN ${CONDA_BIN} install -n base -y -c conda-forge python=3.10
 
 RUN --mount=type=cache,target=/opt/conda/pkgs \
-    /opt/conda/bin/python create_envs.py --manager=${CONDA_BIN} --env-name=${env_name} \
-    --env-type=CI --with-tools-env --tools-env-name=watershed_workflow_tools Linux
+    /opt/conda/bin/python create_envs.py --manager=${CONDA_BIN} --with-user-env=${env_name} \
+    --env-type=CI --with-tools-env=watershed_workflow_tools Linux
 
 #
 # Stage 2 -- add in the pip

--- a/docker/CI-Env.Dockerfile
+++ b/docker/CI-Env.Dockerfile
@@ -81,6 +81,7 @@ RUN /ww_env/bin/conda-unpack
 FROM ubuntu:22.04 AS ww_env_ci
 COPY --from=ww_env_ci_moved /ww_env /ww_env
 ENV PATH="/ww_env/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/ww_env/lib:${LD_LIBRARY_PATH}"
 
 # #
 # # Stage 6 -- run tests!

--- a/docker/CI-Env.Dockerfile
+++ b/docker/CI-Env.Dockerfile
@@ -16,8 +16,8 @@ RUN mkdir environments
 RUN ${CONDA_BIN} install -n base -y -c conda-forge python=3.10
 
 RUN --mount=type=cache,target=/opt/conda/pkgs \
-    /opt/conda/bin/python create_envs.py --manager=${CONDA_BIN} --with-user-env=${env_name} \
-    --env-type=CI --with-tools-env=watershed_workflow_tools Linux
+    /opt/conda/bin/python create_envs.py --OS=Linux --manager=${CONDA_BIN}  \
+    --env-type=CI --with-tools-env=watershed_workflow_tools ${env_name}
 
 #
 # Stage 2 -- add in the pip
@@ -41,7 +41,9 @@ ENV CONDA_PREFIX="/opt/conda/envs/${env_name}"
 # get the source
 WORKDIR /opt/conda/envs/${env_name}/src
 RUN apt-get install git
-RUN git clone -b v2021-10-11 --depth=1 https://github.com/gsjaardema/seacas/ seacas
+RUN git clone -b v2021-10-11 --depth=1 https://github.com/gsjaardema/seacas/ seacas \
+  && sed -i '/const int NC_SZIP_NN/ i\#ifdef NC_SZIP_NN\n#undef NC_SZIP_NN\n#endif' \
+    /opt/conda/envs/${env_name}/src/seacas/packages/seacas/libraries/exodus/src/ex_utils.c
 
 # configure
 WORKDIR /ww/tmp

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -22,19 +22,12 @@ RUN cp watershed_workflowrc examples/.watershed_workflowrc
 RUN echo "data_directory : /ww/examples/Coweeta/input_data" >> examples/.watershed_workflowrc
 
 # run the library tests
-RUN python -m pytest watershed_workflow/test/
-
-# run the test for those sources which can reasonably be expected to work and are most crucial
-RUN python -m pytest watershed_workflow/sources/test/test_source_names.py
-RUN python -m pytest watershed_workflow/sources/test/test_file_manager_daymet.py
-RUN python -m pytest watershed_workflow/sources/test/test_file_manager_nhdplus.py
-RUN python -m pytest watershed_workflow/sources/test/test_file_manager_shape.py
-RUN python -m pytest watershed_workflow/sources/test/test_file_manager_nrcs.py
+RUN conda run -n watershed_workflow_CI python -m pytest watershed_workflow/
 
 # run the notebook examples
-RUN pytest --nbmake --nbmake-kernel=python3 examples/mesh_coweeta.ipynb
-RUN pytest --nbmake --nbmake-kernel=python3 examples/get_Daymet.ipynb
-RUN pytest --nbmake --nbmake-kernel=python3 examples/mesh_mixed_element_toy_problem.ipynb
-RUN pytest --nbmake --nbmake-kernel=python3 examples/mesh_mixed_element_coweeta.ipynb
+RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/mesh_coweeta.ipynb
+RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/get_Daymet.ipynb
+RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/mesh_mixed_element_toy_problem.ipynb
+RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/mesh_mixed_element_coweeta.ipynb
 
 

--- a/docker/configure-seacas.sh
+++ b/docker/configure-seacas.sh
@@ -25,6 +25,8 @@ cmake \
     -D CMAKE_CXX_COMPILER:FILEPATH=${CXX} \
     -D CMAKE_C_COMPILER:FILEPATH=${CC} \
     -D CMAKE_Fortran_COMPILER:FILEPATH=${FC} \
+    -D CMAKE_AR:FILEPATH=/opt/conda/envs/watershed_workflow_tools/bin/gcc-ar \
+    -D CMAKE_RANLIB:FILEPATH=/opt/conda/envs/watershed_workflow_tools/bin/gcc-ranlib \
     -D SEACASProj_SKIP_FORTRANCINTERFACE_VERIFY_TEST:BOOL=ON \
     -D TPL_ENABLE_Netcdf:BOOL=ON \
     -D TPL_ENABLE_HDF5:BOOL=ON \

--- a/environments/create_envs.py
+++ b/environments/create_envs.py
@@ -111,14 +111,22 @@ def get_packages(env_type, os_name=None, extras=False):
             packages.extend(PACKAGES_USER_EXTRAS)
     elif env_type == 'TOOLS':
         packages = PACKAGES_TOOLS.copy()
+	# Previously these were hard-coded to x86_64 architectures
+	# constraint removed so that the package matching os/arch
+	# is automatically selected by conda, but if there is a need
+	# for cross-compiling they should be added back in with an
+	# additional option to specify the architecture. otherwise,
+	# packages via mamba are installed for one arch, but others
+	# that are compiled (e.g., seacas) are build for the other 
+	# arch which causes issues with ld
         if os_name == 'OSX' or os_name == 'Darwin':
-            packages.append('clang_osx-64')
-            packages.append('clangxx_osx-64')
-            packages.append('gfortran_osx-64')
+            packages.append('clang')
+            packages.append('clangxx')
+            packages.append('gfortran')
         elif os_name == 'Linux':
-            packages.append('gcc_linux-64')
-            packages.append('gxx_linux-64')
-            packages.append('gfortran_linux-64')
+            packages.append('gcc')
+            packages.append('gxx')
+            packages.append('gfortran')
         else:
             raise ValueError(f'Cannot determine compilers for unknown platform {os_name}')
     else:

--- a/watershed_workflow/river_tree.py
+++ b/watershed_workflow/river_tree.py
@@ -321,7 +321,7 @@ class River(watershed_workflow.tinytree.Tree):
             self.df[names.CATCHMENT] = self.df[names.CATCHMENT].astype(gpd.array.GeometryDtype())
 
         if crs is not None:
-            self.df.set_crs(crs, inplace=True)
+            self.df.write_crs(crs, inplace=True)
         # end clean up -- hopefully this gets fixed sometime in upstream (pandas or geopandas)
 
         # -- construct the new upstream node inject it into the tree

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -465,17 +465,8 @@ class ManagerMODISAppEEARS:
         if filenames is not None:
             # read the file
             assert variables is not None, "Must provide variables if providing filenames."
-<<<<<<< HEAD
             darrays = dict((var, self._readFile(filename, var)) for (filename, var) in zip(filenames, variables))
             return darrays
-=======
-            darrays = [self._readFile(filename, var) for (filename, var) in zip(filenames, variables)]
-            ds = xr.merge(darrays)
-            for var in ds.variables:
-                ds[var].rio.write_crs(watershed_workflow.crs.latlon_crs)
-            ds.rio.write_crs(watershed_workflow.crs.latlon_crs)
-            return ds
->>>>>>> 31cc3bd (fix rioxarray deprecation warnings)
 
         if task is None and filenames is None:
             if geometry is None or crs is None:

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -465,8 +465,17 @@ class ManagerMODISAppEEARS:
         if filenames is not None:
             # read the file
             assert variables is not None, "Must provide variables if providing filenames."
+<<<<<<< HEAD
             darrays = dict((var, self._readFile(filename, var)) for (filename, var) in zip(filenames, variables))
             return darrays
+=======
+            darrays = [self._readFile(filename, var) for (filename, var) in zip(filenames, variables)]
+            ds = xr.merge(darrays)
+            for var in ds.variables:
+                ds[var].rio.write_crs(watershed_workflow.crs.latlon_crs)
+            ds.rio.write_crs(watershed_workflow.crs.latlon_crs)
+            return ds
+>>>>>>> 31cc3bd (fix rioxarray deprecation warnings)
 
         if task is None and filenames is None:
             if geometry is None or crs is None:

--- a/watershed_workflow/sources/manager_nrcs.py
+++ b/watershed_workflow/sources/manager_nrcs.py
@@ -437,7 +437,7 @@ class ManagerNRCS:
         shapes_no_crs = shapes.groupby('mukey')['geometry'].apply(
             lambda x: shapely.ops.unary_union(x.tolist()) if len(x) > 1 else x.iloc[0]
         ).reset_index()
-        shapes = shapes_no_crs.set_crs(shapes.crs)
+        shapes = shapes_no_crs.write_crs(shapes.crs)
         assert shapes.crs is not None
 
         # read the properties


### PR DESCRIPTION
To complete before merge - current CI fails with:
- [ ] 21 failures
   - [ ] test_alaska, test_default still try to use from_fiona attribute from watershed_workflow.crs (crs doc header also has all the old methods in it)
   - [ ] lots of models.py HTTP errors
   - [ ] some InputValueError's coming from async_retriever/_utils.py (have people been testing with particular python/package versions? or just whatever the most recent mamba solve is?)
- [ ] 72 warnings
  - [ ] pandas type warnings
  - [x] rio.set_crs() -> rio.write_crs()
- [ ] 3 errors.

Close #120 as no longer relevant