### PR TITLE
Porting additional features from v1.6

### DIFF
--- a/watershed_workflow/__init__.py
+++ b/watershed_workflow/__init__.py
@@ -392,6 +392,7 @@ def triangulate(hucs : SplitHUCs,
                 internal_boundaries : Optional[List[shapely.geometry.BaseGeometry | River]] = None,
                 hole_points : Optional[List[shapely.geometry.Point]] = None,
                 additional_vertices : Optional[List[Tuple[float, float]]] = None,
+                handle_stream_triangles : Optional[str] = None,
                 diagnostics : bool = False,
                 verbosity : int = 1,
                 tol : float = 1.0,
@@ -425,6 +426,12 @@ def triangulate(hucs : SplitHUCs,
         List of points inside the polygons to be left as holes/voids (excluded from mesh)
     additional_vertices : list(Tuple[float, float]), optional
         List of points to be inlcuded in the triangulation.
+    handle_stream_triangles : Optional[Literal['refine', 'enforce']] = None
+        Controls how triangles whose vertices all lie on the stream network are handled.
+        'refine' - passes these triangles to general refinement routines, which may leave
+                   some intact.
+        'enforce' - explicitly identifies and splits all such triangles, performing an
+                    additional triangulation pass to ensure none remain.
     diagnostics : bool, optional
         Plot diagnostics graphs of the triangle refinement.
     tol : float, optional
@@ -495,6 +502,11 @@ def triangulate(hucs : SplitHUCs,
     if refine_max_edge_length != None:
         refine_funcs.append(
             watershed_workflow.triangulation.refineByMaxEdgeLength(refine_max_edge_length))
+    if handle_stream_triangles != None:
+        river_corrs = internal_boundaries ### FIX ME -- should point to river_corridors only
+        logging.info("Stream triangles: refining using standard refinement criteria ")
+        refine_funcs.append(
+            watershed_workflow.triangulation.refineByStreamTriangles(river_corrs))
     if refine_polygons != None:
         refine_funcs.append(watershed_workflow.triangulation.refineByPolygons(refine_polygons[0], refine_polygons[1]))
 
@@ -512,8 +524,31 @@ def triangulate(hucs : SplitHUCs,
         min_angle=refine_min_angle,
         enforce_delaunay=enforce_delaunay,
         allow_boundary_steiner=False)
-
     
+    if handle_stream_triangles == 'enforce':
+        logging.info("Stream triangles: enforcing split via additional triangulation pass with prescribed vertices")
+        stream_triangles = watershed_workflow.identifyStreamTriangles(vertices, triangles, river_corrs)
+        if len(stream_triangles) > 0:
+            if additional_vertices is None:
+                additional_vertices = watershed_workflow.river_mesh.getTriangleSplitVertices(
+                    stream_triangles, river_corrs)
+            else:
+                additional_vertices = additional_vertices + watershed_workflow.river_mesh.getTriangleSplitVertices(
+                    stream_triangles, river_corrs)
+                    
+        # triangulate again with additional points to split stream triangles
+        vertices, triangles = watershed_workflow.triangulation.triangulate(
+            hucs,
+            internal_boundaries=internal_boundaries,
+            hole_points=hole_points,
+            additional_vertices=additional_vertices,
+            tol=tol,
+            verbose=verbose,
+            refinement_func=my_refine_func,
+            min_angle=refine_min_angle,
+            enforce_delaunay=enforce_delaunay,
+            allow_boundary_steiner=False)
+        
     if diagnostics:
         logging.info("Plotting triangulation diagnostics")
         if rivers is not None:
@@ -575,6 +610,7 @@ def tessalateRiverAligned(hucs : SplitHUCs,
                           internal_boundaries : Optional[List[River | shapely.geometry.base.BaseGeometry]] = None,
                           hole_points : Optional[List[Tuple[float, float]]] = None,
                           additional_vertices : Optional[List[Tuple[float, float]]] = None,
+                          handle_stream_triangles : Optional[str] = None,
                           as_mesh : bool = True,
                           debug : bool = False,
                           **kwargs) -> \
@@ -606,6 +642,12 @@ def tessalateRiverAligned(hucs : SplitHUCs,
         List of points inside the polygons to be left as holes/voids (excluded from mesh)
     additional_vertices : list(Tuple[float, float]), optional
         List of points to be inlcuded in the triangulation.
+    handle_stream_triangles : Optional[Literal['refine', 'enforce']] = None
+        Controls how triangles whose vertices all lie on the stream network are handled.
+        'refine' - passes these triangles to general refinement routines, which may leave
+                   some intact.
+        'enforce' - explicitly identifies and splits all such triangles, performing an
+                    additional triangulation pass to ensure none remain.
     diagnostics : bool, optional
        If true, prints extra diagnostic info.
     ax : matplotlib Axes object, optional
@@ -656,7 +698,8 @@ def tessalateRiverAligned(hucs : SplitHUCs,
         internal_boundaries = river_corridors + internal_boundaries
         
     tri_res = watershed_workflow.triangulate(hucs, rivers, internal_boundaries,
-                                              hole_points, additional_vertices, as_mesh=False, **kwargs)
+                                              hole_points, additional_vertices, handle_stream_triangles, 
+                                              as_mesh=False, **kwargs)
 
     assert not isinstance(tri_res, watershed_workflow.mesh.Mesh2D)
     assert not isinstance(tri_res[0], watershed_workflow.mesh.Mesh2D)
@@ -755,3 +798,32 @@ def makeMap(m):
     folium.plugins.Fullscreen().add_to(m)
     folium.plugins.MeasureControl().add_to(m)
     return m
+
+
+def identifyStreamTriangles(vertices, triangles, river_corrs, buffer_distance=1):
+    """Identifies triangles that are fully within river corridors.
+    
+    Parameters
+    ----------
+    vertices : np.array((n_points, 2), 'd')
+        Array of triangle vertices
+    triangles : np.array((n_tris, 3), 'i')
+        For each triangle, indices into vertices array
+    river_corrs : list[shapely.geometry.Polygon]
+        List of river corridor polygons
+    buffer_distance : float, optional
+        Distance to buffer points when checking intersection with corridors.
+        Default is 1.
+
+    Returns
+    -------
+    list[np.array]
+        List of vertex arrays for triangles that are fully within river corridors
+    """
+    stream_triangles = []
+    riv_corr = shapely.ops.unary_union(river_corrs).buffer(1)
+    for tri in triangles:
+        tri_verts = vertices[tri]
+        if all(riv_corr.intersects(shapely.geometry.Point(p)) for p in tri_verts):
+            stream_triangles.append(tri_verts)
+    return stream_triangles

--- a/watershed_workflow/regions.py
+++ b/watershed_workflow/regions.py
@@ -280,4 +280,126 @@ def addReachIDRegions(m2 : Mesh2D,
             ls2 = watershed_workflow.mesh.LabeledSet(label + ' surface', setid2, 'CELL', part)
             m2.labeled_sets.append(ls2)
 
+def addDischargeRegions(m2, discharge_points, labels=None, include_cells=True, buffer_width=1):
+    """Add labeled sets for three faces for each discharge point in the river corridor.
+    The three faces include downstream shorter edge of the quad and two edges connecting 
+    two downstream vertices of the quad and non-quad vertice on the bank triangle. 
+    Corresponding upstreams cells (a quad and two triangles) are also added if include_cells is True,
+    which should be use with 
+    <Parameter name="direction normalized flux relative to region" type="string" value="discharge_cell_region_name" />
+    in the ATS observation parameter list in the input file 
 
+    Parameters
+    ----------
+    m2 : watershed_workflow.mesh.Mesh2D
+        The 2D mesh containing river corridor elements
+    discharge_points : list of (x,y) coordinates
+        List of discharge point locations to add regions for
+    labels : list of str, optional
+        Custom labels for each discharge point. If not provided, defaults to
+        'discharge point 0', 'discharge point 1', etc.
+    include_cells : bool, optional
+        If True, add a labeled set for the cells just upstream of discharge faces. Default is True.
+    buffer_width : float, optional
+        Buffer width to identify quad elements containing the discharge point. Default is 1.
+
+    Notes
+    -----
+    For each discharge point, this creates a labeled set containing three edges:
+    1. The downstream edge of the quad element containing the point
+    2. Edge connecting downstream right vertex to right bank
+    3. Edge connecting downstream left vertex to left bank
+    and labeled set containing three cells:
+    1. the quad element containing the point
+    2. the two triangles sharing edges with the quad
+    """
+    if labels is None:
+        labels = ['discharge region ' + str(i) for i in range(len(discharge_points))]
+    
+    # Process each discharge point
+    for discharge_point, label in zip(discharge_points, labels):
+        # Convert coordinates to shapely Point
+        if isinstance(discharge_point, tuple):
+          discharge_point = shapely.geometry.Point(discharge_point)
+        
+        # Find the three edges around this discharge point
+        if include_cells:
+          discharge_edges, discharge_cells = findDischargeEdgesCells(m2, discharge_point, include_cells, buffer_width)
+        else:
+          discharge_edges = findDischargeEdgesCells(m2, discharge_point, include_cells, buffer_width)
+    
+        if discharge_edges:  # Only create labeled set if edges were found
+            ls2 = watershed_workflow.mesh.LabeledSet(label,
+                                                     m2.getNextAvailableLabeledSetID(), 'FACE', discharge_edges)
+            ls2.to_extrude = True
+            m2.labeled_sets.append(ls2)
+            
+            if include_cells and len(discharge_cells) > 0:
+              ls2 = watershed_workflow.mesh.LabeledSet(label + ' cells',
+                                                     m2.getNextAvailableLabeledSetID(), 'CELL', discharge_cells)
+              m2.labeled_sets.append(ls2)
+        else:
+            print(f"No discharge edges found for point {discharge_point}")
+            
+            
+def findDischargeEdgesCells(m2, discharge_point, include_cells=True, buffer_width=1):
+    """Find the edges around a discharge point in a river corridor mesh.
+
+    Parameters
+    ----------
+    m2 : watershed_workflow.mesh.Mesh2D
+        The 2D mesh containing river corridor elements
+    discharge_point : shapely.geometry.Point
+        The discharge point location
+    include_cells : bool, optional
+        If True, include cells in the labeled set. Default is True.
+    buffer_width : float, optional
+        Buffer width to identify quad elements containing the discharge point. Default is 1.
+
+    Returns
+    -------
+    list of tuples
+        List of (vertex1, vertex2) pairs defining edges.
+        if include_cells is True, also returns the cells just upstream of the edges.
+    """
+    # find the quad element that contains the discharge point
+    discharge_quad = None
+    discharge_point_buffer = discharge_point.buffer(buffer_width)
+    for c, conn in enumerate(m2.conn):
+        if len(conn) > 3:
+          poly = shapely.geometry.Polygon(m2.coords[conn])
+          if poly.intersects(discharge_point_buffer):
+              discharge_quad = conn
+              discharge_quad_id = c
+              break   
+    if discharge_quad is None:
+        return []
+
+    # get bank nodes and construct edges
+    bank_node_ids = watershed_workflow.condition._findBankVerticesFromElem(m2, discharge_quad)  
+    discharge_edges = [
+        (discharge_quad[0], bank_node_ids[0]),  # edge to right bank
+        (discharge_quad[-1], bank_node_ids[1]), # edge to left bank 
+        (discharge_quad[-1], discharge_quad[0])  # downstream edge
+    ]
+    
+    if include_cells:
+        discharge_cells=[]
+        # edge on the right as we look from the downstream direction
+        edge_r = list(m2.cell_edges(discharge_quad))[0]
+        cell_ids = m2.edges_to_cells[edge_r]
+        bank_cell_id = next(cell_id for cell_id, conn in zip(cell_ids, [m2.conn[cell_id] for cell_id in cell_ids]) if len(conn) == 3)
+        discharge_cells.append(bank_cell_id)
+        
+        # edge on the left as we look from the downstream direction
+        edge_l = list(m2.cell_edges(discharge_quad))[-2]
+        cell_ids = m2.edges_to_cells[edge_l]
+        bank_cell_id = next(cell_id for cell_id, conn in zip(cell_ids, [m2.conn[cell_id] for cell_id in cell_ids]) if len(conn) == 3)
+        discharge_cells.append(bank_cell_id)
+        
+        # quad element
+        discharge_cells.append(discharge_quad_id)
+        return discharge_edges, discharge_cells
+      
+    return discharge_edges
+ 

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -164,6 +164,7 @@ class NodesEdges:
 def triangulate(hucs: watershed_workflow.split_hucs.SplitHUCs,
                 internal_boundaries: Optional[List[shapely.geometry.LineString]] = None,
                 hole_points: Optional[List[shapely.geometry.Point]] = None,
+                additional_vertices: Optional[List[Tuple[float, float]]] = None,
                 tol: float = 1.0,
                 **kwargs) -> Tuple[np.ndarray, np.ndarray]:
     """Triangulates HUCs and rivers.
@@ -181,6 +182,8 @@ def triangulate(hucs: watershed_workflow.split_hucs.SplitHUCs,
         must be included in the mesh.
     hole_points : list(shapely.Point), optional
         List of points inside the polygons to be left as holes/voids (excluded from mesh).
+    additional_vertices : list(Tuple[float, float]), optional
+        List of points to be included in the triangulation.
     tol : float, optional
         Set tolerance for minimum distance between two nodes. The unit
         is the same as that of the watershed's CRS. The default is 1.
@@ -208,6 +211,10 @@ def triangulate(hucs: watershed_workflow.split_hucs.SplitHUCs,
     logging.info(" building graph data structures")
     info = meshpy.triangle.MeshInfo()
     nodes = np.array(list(nodes_edges.nodes))
+    
+    # add additional vertices if provided
+    if additional_vertices is not None:
+        nodes = np.vstack((nodes, additional_vertices))
 
     pdata = [tuple([float(c) for c in p]) for p in nodes]
     info.set_points(pdata)

--- a/watershed_workflow/triangulation.py
+++ b/watershed_workflow/triangulation.py
@@ -336,6 +336,15 @@ def refineByPolygons(polygons, areas):
 
     return refine
 
+def refineByStreamTriangles(river_corrs):
+    """Returns a refinement function for triangles that have all three vertices on stream mesh."""
+    riv_corr = shapely.ops.unary_union(river_corrs).buffer(1)
+
+    def refine(vertices, area):
+        return all(riv_corr.intersects(shapely.geometry.Point(p)) for p in vertices)
+
+    return refine
+
 
 def refineByMaxEdgeLength(edge_length):
     """Returns a refinement function based on max edge length, for use with Triangle."""


### PR DESCRIPTION
This PR brings in three main features from v1.6:

1. **Add three-face discharge regions along river corridors**
Add labeled sets for three faces for each discharge point in the river corridor. The three faces include downstream shorter edge of the quad and two edges connecting two downstream vertices of the quad and non-quad vertice on the bank triangle. Corresponding upstreams cells (a quad and two triangles) are also added for `<Parameter name="direction normalized flux relative to region" type="string" value="discharge_cell_region_name" />` in the ATS observation parameter list in the input file.

2. **handle stream triangles**
Implement two-stage handling for stream triangles in river-aligned meshing

Triangles with all three vertices lying on the stream network can cause issues for applications such as stream network connectivity, as they may divert flow away from the corridor and act like braided channels. To address this, a two-stage treatment is introduced, controlled by the
optional flag `handle_stream_triangles` : {'none', 'refine', 'enforce'} in the `tessellate_river_aligned` function.

- 'refine' : Identifies stream triangles and passes them to the refinement
  routines in the triangle library. This removes most cases but does not
  strictly enforce splitting, as the triangulation algorithm must balance
  competing constraints such as angle and cell-size criteria.

- 'enforce' : Explicitly splits remaining stream triangles that could not
  be refined, by inserting additional points (typically the midpoint of the
  off-corridor edge) during a second triangulation pass.

This ensures robust connectivity and avoids artificial braiding in the
stream-corridor mesh.
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/489d3627-f05c-4da2-8595-ba28595cebf4" />
 
3. **prescribed additional vertices and hole points**
Allow users to provide _triangle_ arguments through high-level function, specifically, hole points and additional vertices for triangulation. Currently, hole points are defined only by river meshing routine.