### PR TITLE
fix: replace hardcoded native_end dates 

### DIFF
--- a/watershed_workflow/sources/manager_aorc.py
+++ b/watershed_workflow/sources/manager_aorc.py
@@ -98,7 +98,8 @@ class ManagerAORC(manager_dataset.ManagerDataset):
 
     def __init__(self):
         native_start = cftime.datetime(1980, 1, 1, calendar='standard')
-        native_end = cftime.datetime(2024, 12, 31, calendar='standard')
+        _today = datetime.date.today()
+        native_end = cftime.datetime(_today.year, _today.month, _today.day, calendar='standard')
         native_crs = CRS.from_epsg(4326)
         native_resolution = 0.00833333  # 30 arc-second resolution
 

--- a/watershed_workflow/sources/manager_daymet.py
+++ b/watershed_workflow/sources/manager_daymet.py
@@ -71,7 +71,8 @@ class ManagerDaymet(manager_dataset.ManagerDataset):
     def __init__(self):
         native_resolution = 1000.0  # 1km in meters
         native_start = cftime.datetime(1980, 1, 1, calendar='noleap')
-        native_end = cftime.datetime(2023, 12, 31, calendar='noleap')
+        _today = datetime.date.today()
+        native_end = cftime.datetime(_today.year, _today.month, _today.day, calendar='noleap')
         native_crs_daymet = CRS.from_proj4(
             '+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs'
         )

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -116,7 +116,8 @@ class ManagerMODISAppEEARS(manager_dataset.ManagerDataset):
         import cftime
         native_resolution = 500.0 * 9.e-6  # in native_crs (degrees)
         native_start = cftime.datetime(2002, 7, 1, calendar='standard')
-        native_end = cftime.datetime(2024, 1, 1, calendar='standard')
+        _today = datetime.date.today()
+        native_end = cftime.datetime(_today.year, _today.month, _today.day, calendar='standard')
         native_crs = CRS.from_epsg(4269)  # WGS84 Geographic
         valid_variables = ['LAI', 'LULC']
         default_variables = ['LAI', 'LULC']


### PR DESCRIPTION
MODIS, AORC, and DayMet managers now compute native_end dynamically from datetime.date.today() so the upper bound never silently truncates requests for recent data.