### PR TITLE
fix meshpy Triangle crash on linux-aarch64 by disabling FP contraction

### DIFF
--- a/docker/CI-Env.Dockerfile
+++ b/docker/CI-Env.Dockerfile
@@ -17,40 +17,32 @@ RUN echo "TARGETARCH=${TARGETARCH}" && \
     uname -m && \
     conda info | grep platform
 
-# copy over create_envs
+# copy over create_envs and requirements.txt (pip-installed by create_envs.py itself)
 WORKDIR /ww/tmp
-COPY environments/create_envs.py /ww/tmp/create_envs.py 
+COPY environments/create_envs.py /ww/tmp/create_envs.py
+COPY requirements.txt /ww/tmp/requirements.txt
 RUN mkdir environments
 
-# Create the environment
+# set compilers from watershed_workflow_tools environment -- this must happen
+# BEFORE create_envs.py runs, since it also pip-installs requirements.txt
+# (meshpy has no linux-aarch64 wheel and must build from source there, which
+# needs g++/gcc from the tools env on PATH)
+ENV COMPILERS=/opt/conda/envs/watershed_workflow_tools
+ENV PATH="${COMPILERS}/bin:${PATH}"
+
+# Create the environment (also pip-installs requirements.txt, constrained
+# against the conda env's own package versions -- see create_envs.py)
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     /opt/conda/bin/python create_envs.py --OS=Linux --manager=${CONDA_BIN}  \
     --env-type=CI --with-tools-env=watershed_workflow_tools ${env_name}
 
 # test the environment
-RUN ${CONDA_BIN} run --name ${env_name} python -c "import pymetis; import geopandas"
-
-# set compilers from watershed_workflow_tools environment
-ENV COMPILERS=/opt/conda/envs/watershed_workflow_tools 
-ENV PATH="${COMPILERS}/bin:${PATH}"
+RUN ${CONDA_BIN} run --name ${env_name} python -c "import pymetis; import geopandas; import meshpy"
 
 #
-# Stage 2 -- add in the pip
+# Stage 2 -- add in Exodus
 #
-FROM ww_env_base_ci AS ww_env_pip_ci
-
-WORKDIR /ww/tmp
-COPY requirements.txt /ww/tmp/requirements.txt
-
-RUN ${CONDA_BIN} run --name ${env_name} python -m pip install -r requirements.txt
-
-# test the environment
-RUN ${CONDA_BIN} run --name ${env_name} python -c "import meshpy"
-
-#
-# Stage 3 -- add in Exodus
-#
-FROM ww_env_pip_ci AS ww_env_exodus_ci
+FROM ww_env_base_ci AS ww_env_exodus_ci
 
 ENV SEACAS_DIR="/opt/conda/envs/${env_name}"
 ENV CONDA_PREFIX="/opt/conda/envs/${env_name}"

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -28,6 +28,6 @@ RUN conda run -n watershed_workflow_CI python -m pytest watershed_workflow/test
 RUN conda run -n watershed_workflow_CI python -m pytest watershed_workflow/sources/test
 
 # run the notebook examples
-RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/coweeta_stream_aligned_mesh.ipynb
+RUN conda run -n watershed_workflow_CI pytest --nbmake --nbmake-kernel=python3 examples/coweeta_stream_aligned_mesh.ipynb examples/toy_problem_stream_aligned_mesh.ipynb
 
 

--- a/docker/configure-seacas.sh
+++ b/docker/configure-seacas.sh
@@ -38,6 +38,7 @@ cmake \
     -D Netcdf_INCLUDE_DIRS:PATH=${CONDA_PREFIX}/include \
     -D HDF5_ROOT:PATH=${CONDA_PREFIX} \
     -D HDF5_NO_SYSTEM_PATHS=ON \
+    -D TPL_HDF5_LIBRARIES:STRING="${CONDA_PREFIX}/lib/libhdf5.so;${CONDA_PREFIX}/lib/libhdf5_hl.so" \
 ${SEACAS_SRC_DIR}
 
 

--- a/environments/create_envs.py
+++ b/environments/create_envs.py
@@ -196,7 +196,8 @@ def create_env_local(env_type, os_name, packages, env_name=None, dry_run=False, 
 
     # call conda env create
     if dry_run:
-        return print(cmd)
+        print(cmd)
+        return env_name
     subprocess.run(cmd, check=True)
 
     # set an environment variable so the user can figure out what we just made
@@ -206,9 +207,54 @@ def create_env_local(env_type, os_name, packages, env_name=None, dry_run=False, 
         os.environ[f'WATERSHED_WORKFLOW_{env_type}_ENV'] = env_name
     return env_name
 
-def create_and_dump_env_local(env_type, os_name, packages, env_name=None, dump_only=False, dry_run=False, use_local=False):
+def pip_install_requirements(env_name, requirements_filename='requirements.txt', dry_run=False):
+    """Pip-installs requirements.txt into an existing conda env.
+
+    Generates a constraints file from the conda env's already-installed
+    packages first, so pip cannot silently replace a conda-installed
+    package (e.g. numpy) with an incompatible PyPI wheel to satisfy some
+    pip-only package's transitive dependency.
+    """
+    constraints_filename = os.path.join(os.path.dirname(requirements_filename) or '.', 'constraints.txt')
+
+    # NOTE: use `pip list --format=freeze`, not `pip freeze` -- for packages
+    # conda built locally (rattler-build/conda-build), `pip freeze` reports a
+    # `file:///.../conda-bld/.../work/dist/....whl` provenance URL pointing at
+    # the (long-gone) build sandbox instead of a plain version, which then
+    # fails to resolve when used as a constraint.
+    freeze_cmd = [PACKAGE_MANAGER, 'run', '--name', env_name, 'python', '-m', 'pip', 'list', '--format=freeze']
+    if dry_run:
+        print(freeze_cmd, '>', constraints_filename)
+    else:
+        result = subprocess.run(freeze_cmd, check=True, capture_output=True)
+        with open(constraints_filename, 'w') as fid:
+            fid.write(result.stdout.decode('utf-8'))
+
+    install_cmd = [PACKAGE_MANAGER, 'run', '--name', env_name, 'python', '-m', 'pip', 'install',
+                   '-c', constraints_filename, '-r', requirements_filename]
+    if dry_run:
+        return print(install_cmd)
+
+    # meshpy has no linux-aarch64 wheel on PyPI and must build its bundled
+    # Triangle sources from scratch there.  GCC on aarch64 fuses
+    # multiply-adds into FMA instructions at -O2/-O3 by default
+    # (-ffp-contract=fast), which changes intermediate rounding and breaks
+    # Triangle's exact-arithmetic orientation predicates (finddirection()
+    # aborts on otherwise-valid input).  Disabling FP contraction fixes it
+    # without giving up optimization.  Harmless to set for the whole
+    # requirements.txt install since the other packages there are pure Python.
+    env = os.environ.copy()
+    for var in ('CFLAGS', 'CXXFLAGS'):
+        env[var] = (env.get(var, '') + ' -ffp-contract=off').strip()
+    subprocess.run(install_cmd, check=True, env=env)
+
+
+def create_and_dump_env_local(env_type, os_name, packages, env_name=None, dump_only=False, dry_run=False, use_local=False,
+                               pip_requirements=True, requirements_filename='requirements.txt'):
     if not dump_only:
-        create_env_local(env_type, os_name, packages, env_name, dry_run, use_local)
+        env_name = create_env_local(env_type, os_name, packages, env_name, dry_run, use_local)
+        if pip_requirements:
+            pip_install_requirements(env_name, requirements_filename, dry_run)
         dump_env_local(env_type, os_name, env_name)
 
 
@@ -235,6 +281,11 @@ if __name__ == '__main__':
                              'and a OS-specific filename for writing the environment.yml file.')
     parser.add_argument('--use-local', action='store_true',
                         help='Use local emulated channel, with locally built packages, in all conda create calls.')
+    parser.add_argument('--no-pip-requirements', action='store_true',
+                        help='Skip pip-installing requirements.txt (e.g. rosetta-soil, meshpy, hf-hydrodata) into '
+                             'the workflow environment after conda create.  By default this runs automatically, '
+                             'first generating a constraints.txt from the conda env so pip cannot silently '
+                             'replace a conda-installed package (e.g. numpy) with an incompatible PyPI wheel.')
     parser.add_argument('ENV_NAME', type=str, help='Name for this environement')
     args = parser.parse_args()
 
@@ -245,17 +296,24 @@ if __name__ == '__main__':
 
     if args.env_type == 'STANDARD':
         args.env_type = None
+
+    # create the tools environment FIRST -- meshpy (in requirements.txt) has
+    # no linux-aarch64 wheel on PyPI and must build from source there, which
+    # needs the compiler toolchain this env provides on PATH (see
+    # CI-Env.Dockerfile, which exports PATH from this env before calling us).
+    if args.with_tools_env is not None:
+        packages = get_packages('TOOLS', args.OS)
+        create_and_dump_env_local('TOOLS', args.OS, packages, args.with_tools_env, args.dump_only, args.dry_run,
+                                   pip_requirements=False)
+
     if not args.without_ww_env:
         # create the workflow environment
         packages = get_packages(args.env_type, args.OS)
-        create_and_dump_env_local(args.env_type, args.OS, packages, args.ENV_NAME, args.dump_only, args.dry_run, args.use_local)
+        create_and_dump_env_local(args.env_type, args.OS, packages, args.ENV_NAME, args.dump_only, args.dry_run, args.use_local,
+                                   pip_requirements=not args.no_pip_requirements)
 
     if args.with_user_env is not None:
         # create the user environment
         packages = get_packages('USER', args.OS, args.user_env_extras)
-        create_and_dump_env_local('USER', args.OS, packages, args.with_user_env, args.dump_only, args.dry_run)
-
-    if args.with_tools_env is not None:
-        # create the tools environment
-        packages = get_packages('TOOLS', args.OS)
-        create_and_dump_env_local('TOOLS', args.OS, packages, args.with_tools_env, args.dump_only, args.dry_run)
+        create_and_dump_env_local('USER', args.OS, packages, args.with_user_env, args.dump_only, args.dry_run,
+                                   pip_requirements=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 # packages here MUST be installed via Anaconda or done manually.
 # However, there are a few requirements that cannot be provided via
 # conda, but CAN be provided via pip, so we get those here...
-rosetta-soil
+rosetta-soil==0.1.2  # >=0.3 removed SoilData.from_array(), which watershed_workflow/soil_properties.py depends on
 meshpy
 hf-hydrodata


### PR DESCRIPTION
meshpy has no linux-aarch64 wheel on PyPI and must build its bundled Triangle sources from scratch on that platform.  GCC fuses multiply-adds into FMA instructions at -O2/-O3 by default there, which changes intermediate rounding and breaks Triangle's exact-arithmetic orientation predicates -- finddirection() aborts (and kills the whole process) on otherwise-valid input.  Disabling FP contraction (-ffp-contract=off) during the requirements.txt pip install fixes it without giving up optimization.

Also folds in the pip-install step (with a constraints.txt generated from the conda env) directly into create_envs.py, so pip can't silently replace a conda-installed package like numpy with an incompatible PyPI wheel to satisfy some pip-only package's transitive dependency (e.g. hf-hydrodata -> pftools -> numba<2.5).  This requires building the tools env (which provides the compiler) before the main env's pip step, so create_envs.py's build order changed accordingly.

Adds toy_problem_stream_aligned_mesh.ipynb to CI's notebook test set -- this notebook triangulates a PSLG that triggers the crash above, so it should catch regressions in this fix.