### PR TITLE
Make native_end/native_start self-perpetuating and variable-dependent

### DIFF
--- a/watershed_workflow/sources/manager.py
+++ b/watershed_workflow/sources/manager.py
@@ -47,11 +47,24 @@ class ManagerAttributes:
         Characteristic resolution of the data in ``native_crs_in`` units.
         Used for buffering and cache-directory snapping.
     native_start : object, optional
-        Earliest start date of the data (cftime.datetime), or ``None`` for
-        non-temporal datasets.
+        Earliest start date of the data (cftime.datetime).  Used as the
+        default implementation of ``ManagerDataset._getNativeStart()``.
+        May be ``None`` for non-temporal data, or for a temporal manager
+        that overrides ``_getNativeStart()`` with variable-dependent
+        logic (in which case ``native_calendar`` must be given).
     native_end : object, optional
-        Latest end date of the data (cftime.datetime), or ``None`` for
-        non-temporal datasets.
+        Latest end date of the data (cftime.datetime).  Used as the
+        default implementation of ``ManagerDataset._getNativeEnd()``.
+        May be ``None`` for non-temporal data, or for a temporal manager
+        that overrides ``_getNativeEnd()`` with variable-dependent logic
+        (in which case ``native_calendar`` must be given).
+    native_calendar : str or None, optional
+        cftime calendar (e.g. ``'standard'``, ``'noleap'``).  Required
+        when both ``native_start`` and ``native_end`` are ``None`` but
+        the manager is still temporal; calendars cannot be assumed equal
+        across variables (e.g. noleap vs. standard), so the manager must
+        state it explicitly.  When omitted, detected from whichever of
+        ``native_start``/``native_end`` is given.
     native_id_field : str or None, optional
         Name of the primary ID field in the native data.  ``None`` for
         raster managers.
@@ -89,6 +102,7 @@ class ManagerAttributes:
     native_resolution: float | None = None
     native_start: object = None     # cftime.datetime | None
     native_end: object = None       # cftime.datetime | None
+    native_calendar: str | None = None
     native_id_field: str | None = None
 
     # Variable selection

--- a/watershed_workflow/sources/manager_aorc.py
+++ b/watershed_workflow/sources/manager_aorc.py
@@ -89,9 +89,15 @@ class ManagerAORC(manager_dataset.ManagerDataset):
                          'TMP_2maboveground', 'UGRD_10maboveground', 'VGRD_10maboveground']
     URL = 's3://noaa-nws-aorc-v1-1-1km'
 
+    # AORC publishes on a near-real-time, rolling basis with roughly a
+    # 9-day production lag; use a slightly more conservative buffer to
+    # absorb pipeline hiccups (e.g. the April 2026 Zarr reprocessing).
+    NATIVE_END_LAG_DAYS = 15
+
     def __init__(self):
         native_start = cftime.datetime(1980, 1, 1, calendar='standard')
-        native_end = cftime.datetime(2024, 12, 31, calendar='standard')
+        native_end = manager_dataset.ManagerDataset._todayMinusLag(self.NATIVE_END_LAG_DAYS,
+                                                                    calendar='standard')
         native_crs = CRS.from_epsg(4326)
         native_resolution = 0.00833333  # 30 arc-second resolution
 

--- a/watershed_workflow/sources/manager_dataset.py
+++ b/watershed_workflow/sources/manager_dataset.py
@@ -8,6 +8,7 @@ the fetching.
 import abc
 import concurrent.futures
 import dataclasses
+import datetime
 import enum
 from typing import Optional, List
 import numpy as np
@@ -129,11 +130,27 @@ class ManagerDataset(Manager, abc.ABC):
         ----------
         attrs : ManagerAttributes
             Plain-data object holding all metadata for this manager.
+            ``attrs.native_start``/``attrs.native_end`` are used as the
+            default implementation of ``_getNativeStart()``/
+            ``_getNativeEnd()``; both may be ``None`` for non-temporal
+            data, or for a temporal manager that overrides those hooks
+            with variable-dependent logic (in which case
+            ``attrs.native_calendar`` must be given, since calendars
+            cannot be assumed equal across variables, e.g. noleap vs.
+            standard).  When ``attrs.native_calendar`` is omitted, it is
+            detected from whichever of ``native_start``/``native_end``
+            is given.
         """
         super().__init__(attrs)
+        self._native_start = attrs.native_start
+        self._native_end = attrs.native_end
 
-        # Detect calendar from native dates
-        self.native_calendar = self._detectCalendar()
+        # Calendar must be explicit when neither native date is given.
+        calendar = attrs.native_calendar
+        if calendar is not None:
+            self.native_calendar = calendar
+        else:
+            self.native_calendar = self._detectCalendar()
 
         # Background executor for _waitAndDownload tasks
         self._executor = concurrent.futures.ThreadPoolExecutor()
@@ -286,6 +303,29 @@ class ManagerDataset(Manager, abc.ABC):
     #
     # Helper functions
     #
+    @staticmethod
+    def _todayMinusLag(lag_days: int, calendar: str = 'standard') -> cftime._cftime.datetime:
+        """Compute today minus a publication lag, for bounding native_end on near-real-time sources.
+
+        Parameters
+        ----------
+        lag_days : int
+            Number of days by which the source's published data trails today.
+        calendar : str, optional
+            cftime calendar to construct the date in.
+
+        Returns
+        -------
+        cftime._cftime.datetime
+            Today minus lag_days, in the requested calendar.  For
+            'noleap'/'365_day' calendars, Feb 29 is clamped to Feb 28.
+        """
+        date = datetime.date.today() - datetime.timedelta(days=lag_days)
+        day = date.day
+        if calendar in ('noleap', '365_day') and date.month == 2 and date.day == 29:
+            day = 28
+        return cftime.datetime(date.year, date.month, day, calendar=calendar)
+
     def _detectCalendar(self) -> str:
         """Detect the calendar type from native start/end dates.
 
@@ -294,12 +334,13 @@ class ManagerDataset(Manager, abc.ABC):
         str
             Calendar type ('noleap', 'standard', etc.) or 'standard' as default.
         """
-        for date in [self.native_start, self.native_end]:
+        for date in [self._native_start, self._native_end]:
             if date is not None and hasattr(date, 'calendar'):
                 return date.calendar
         return 'standard'
 
-    def _parseDate(self, date: str | int | cftime._cftime.datetime | None, is_start: bool) -> cftime._cftime.datetime | None:
+    def _parseDate(self, date: str | int | cftime._cftime.datetime | None, is_start: bool,
+                   default: cftime._cftime.datetime | None = None) -> cftime._cftime.datetime | None:
         """Parse date input into cftime datetime.
 
         Parameters
@@ -309,6 +350,8 @@ class ManagerDataset(Manager, abc.ABC):
         is_start : bool
             True if this is a start date (uses Jan 1 for int years).
             False if this is an end date (uses Dec 31 for int years).
+        default : cftime._cftime.datetime or None, optional
+            Value to return when date is None.
 
         Returns
         -------
@@ -316,7 +359,7 @@ class ManagerDataset(Manager, abc.ABC):
             Parsed datetime or None.
         """
         if date is None:
-            return self.native_start if is_start else self.native_end
+            return default
         elif isinstance(date, str):
             return cftime.datetime.strptime(date, "%Y-%m-%d", calendar=self.native_calendar)
         elif isinstance(date, int):
@@ -332,6 +375,73 @@ class ManagerDataset(Manager, abc.ABC):
             return date
         else:
             raise TypeError(f"Unsupported date type: {type(date)}")
+
+    def _getNativeStart(self, variables: List[str] | None) -> cftime._cftime.datetime | None:
+        """Return the native_start bound to validate against, given requested variables.
+
+        Parameters
+        ----------
+        variables : list of str or None
+            Variables being requested (None means default_variables).
+
+        Returns
+        -------
+        cftime._cftime.datetime or None
+            Defaults to the native_start passed at construction.  Managers
+            whose variables have different start dates should override
+            this to return a variable-specific bound.
+        """
+        return self._native_start
+
+    def _getNativeEnd(self, variables: List[str] | None) -> cftime._cftime.datetime | None:
+        """Return the native_end bound to validate against, given requested variables.
+
+        Parameters
+        ----------
+        variables : list of str or None
+            Variables being requested (None means default_variables).
+
+        Returns
+        -------
+        cftime._cftime.datetime or None
+            Defaults to the native_end passed at construction.  Managers
+            whose variables have different publication schedules (e.g.
+            MODIS LAI vs. LULC) should override this to return a
+            variable-specific bound.
+        """
+        return self._native_end
+
+    def getNativeStart(self, variables: List[str] | None = None) -> cftime._cftime.datetime | None:
+        """Return the earliest available start date for the given variables.
+
+        Parameters
+        ----------
+        variables : list of str or None, optional
+            Variables to check.  Default is ``default_variables``.
+
+        Returns
+        -------
+        cftime._cftime.datetime or None
+            Earliest available start date, or None for non-temporal data.
+        """
+        variables = variables if variables is not None else self.default_variables
+        return self._getNativeStart(variables)
+
+    def getNativeEnd(self, variables: List[str] | None = None) -> cftime._cftime.datetime | None:
+        """Return the latest available end date for the given variables.
+
+        Parameters
+        ----------
+        variables : list of str or None, optional
+            Variables to check.  Default is ``default_variables``.
+
+        Returns
+        -------
+        cftime._cftime.datetime or None
+            Latest available end date, or None for non-temporal data.
+        """
+        variables = variables if variables is not None else self.default_variables
+        return self._getNativeEnd(variables)
 
     def _validateDate(self, date: cftime._cftime.datetime | None, bound: cftime._cftime.datetime | None, is_start: bool) -> None:
         """Validate date against bounds.
@@ -425,21 +535,25 @@ class ManagerDataset(Manager, abc.ABC):
         polygon = polygon.buffer(3 * self.native_resolution)
         logging.info(f'... buffered shape area = {polygon.area}')
 
-        # Parse and validate dates, temporal_resampling
-        parsed_start = self._parseDate(start, True)
-        self._validateDate(parsed_start, self.native_start, True)
+        # Parse and validate variables first -- date bounds may depend on
+        # which variables are requested (e.g. MODIS LAI vs. LULC).
+        parsed_variables = self._validateVariables(variables)
 
-        parsed_end = self._parseDate(end, False)
-        self._validateDate(parsed_end, self.native_end, False)
+        # Parse and validate dates, temporal_resampling
+        native_start = self._getNativeStart(parsed_variables)
+        native_end = self._getNativeEnd(parsed_variables)
+
+        parsed_start = self._parseDate(start, True, default=native_start)
+        self._validateDate(parsed_start, native_start, True)
+
+        parsed_end = self._parseDate(end, False, default=native_end)
+        self._validateDate(parsed_end, native_end, False)
 
         if temporal_resampling is not None and parsed_start is None:
             raise ValueError("Cannot resample non-temporal dataset.")
 
         if parsed_start is not None and parsed_end is not None and parsed_start > parsed_end:
             raise ValueError(f"start ({parsed_start}) must not be after end ({parsed_end}).")
-
-        # Parse and validate variables
-        parsed_variables = self._validateVariables(variables)
 
         return self.Request(self, polygon, out_crs, parsed_start, parsed_end, temporal_resampling, parsed_variables)
 

--- a/watershed_workflow/sources/manager_daymet.py
+++ b/watershed_workflow/sources/manager_daymet.py
@@ -68,7 +68,9 @@ class ManagerDaymet(manager_dataset.ManagerDataset):
     def __init__(self):
         native_resolution = 1000.0  # 1km in meters
         native_start = cftime.datetime(1980, 1, 1, calendar='noleap')
-        native_end = cftime.datetime(2023, 12, 31, calendar='noleap')
+        # DayMet is released annually, ~30+ days after year-end; update this
+        # once the following year's data is confirmed published.
+        native_end = cftime.datetime(2024, 12, 31, calendar='noleap')
         native_crs_daymet = watershed_workflow.crs.from_string(
             '+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs'
         )

--- a/watershed_workflow/sources/manager_modis_appeears.py
+++ b/watershed_workflow/sources/manager_modis_appeears.py
@@ -7,7 +7,7 @@ import logging
 import netrc
 import requests
 import time
-import cftime, datetime
+import cftime
 import shapely
 import numpy as np
 import rasterio.transform
@@ -90,14 +90,24 @@ class ManagerMODISAppEEARS(manager_dataset.ManagerDataset):
     _STATUS_URL = "https://appeears.earthdatacloud.nasa.gov/api/status/"
     _BUNDLE_URL_TEMPLATE = "https://appeears.earthdatacloud.nasa.gov/api/bundle/{0}"
 
+    # native_end: fixed last-known-good date for products with irregular
+    # or annual release schedules.  Omit this key for products released
+    # on a near-real-time, roughly-constant-lag basis -- their bound is
+    # instead computed as today minus native_end_lag_days.
     _PRODUCTS = {
         'LAI': {
             "layer": "Lai_500m",
-            "product": "MCD15A3H.061"
+            "product": "MCD15A3H.061",
+            "native_end_lag_days": 15,
         },
         'LULC': {
             "layer": "LC_Type1",
-            "product": "MCD12Q1.061"
+            "product": "MCD12Q1.061",
+            # MCD12Q1.061 is annual and only reliably available through
+            # 2024 -- the science team has not kept training data
+            # current since 2020.  Update once a later year is
+            # confirmed published.
+            "native_end": cftime.datetime(2024, 12, 31, calendar='standard'),
         },
     }
 
@@ -115,7 +125,6 @@ class ManagerMODISAppEEARS(manager_dataset.ManagerDataset):
         # 500 m / (pi/180 * 6 371 007.181 m/deg) ≈ 4.49e-3 deg
         native_resolution = 500.0 / (math.pi / 180.0 * 6_371_007.181)
         native_start = cftime.datetime(2002, 7, 1, calendar='standard')
-        native_end = cftime.datetime(2024, 1, 1, calendar='standard')
 
         attrs = ManagerAttributes(
             category='land_cover',
@@ -131,10 +140,12 @@ class ManagerMODISAppEEARS(manager_dataset.ManagerDataset):
             native_crs_out=native_crs_out,
             native_resolution=native_resolution,
             native_start=native_start,
-            native_end=native_end,
+            # native_end is variable-dependent -- see _getNativeEnd().
+            native_end=None,
             valid_variables=['LAI', 'LULC'],
             default_variables=['LAI', 'LULC'],
             is_temporal=True,
+            native_calendar='standard',
         )
         super().__init__(attrs)
 
@@ -159,6 +170,19 @@ class ManagerMODISAppEEARS(manager_dataset.ManagerDataset):
             if not os.path.isfile(os.path.join(dir, f'{var}.nc')):
                 return False
         return True
+
+    @classmethod
+    def _productNativeEnd(cls, product_key):
+        """Return a single product's native_end: fixed date if given, else today minus its lag."""
+        info = cls._PRODUCTS[product_key]
+        if 'native_end' in info:
+            return info['native_end']
+        return manager_dataset.ManagerDataset._todayMinusLag(info['native_end_lag_days'],
+                                                              calendar='standard')
+
+    def _getNativeEnd(self, variables):
+        """Return the most conservative native_end across the requested products."""
+        return min(self._productNativeEnd(var) for var in variables)
 
     def _authenticate(self,
                       username: Optional[str] = None,

--- a/watershed_workflow/sources/manager_modis_earthdata.py
+++ b/watershed_workflow/sources/manager_modis_earthdata.py
@@ -84,6 +84,9 @@ _WGS84_TO_SINU = pyproj.Transformer.from_crs(
 # ---------------------------------------------------------------------------
 #: Per-variable product metadata.
 #: ``opendap`` — True if cloud OPeNDAP is available for this product.
+#: ``native_end``/``native_end_lag_days`` — see ``_getNativeEnd()``: LAI is
+#: released on a near-real-time, roughly-constant-lag basis, while LULC is
+#: annual and only reliably available through a fixed, manually-bumped year.
 _PRODUCTS: Dict[str, Dict] = {
     'LAI': {
         'product': 'MCD15A3H',
@@ -95,6 +98,7 @@ _PRODUCTS: Dict[str, Dict] = {
         'long_name': 'Leaf Area Index',
         'units': 'm^2/m^2',
         'opendap': False,   # not yet available at LP DAAC cloud
+        'native_end_lag_days': 15,
     },
     'LULC': {
         'product': 'MCD12Q1',
@@ -106,6 +110,10 @@ _PRODUCTS: Dict[str, Dict] = {
         'long_name': 'Land Cover Type 1 (IGBP)',
         'units': 'class',
         'opendap': False,   # use HDF4 to match LAI pixel grid
+        # MCD12Q1.061 is annual and only reliably available through 2024 --
+        # the science team has not kept training data current since 2020.
+        # Update once a later year is confirmed published.
+        'native_end': cftime.datetime(2024, 12, 31, calendar='standard'),
     },
 }
 
@@ -294,7 +302,6 @@ class ManagerMODISEarthdata(manager_dataset.ManagerDataset):
             Default is ``False``.
         """
         native_start = cftime.datetime(2002, 7, 4, calendar='standard')
-        native_end = cftime.datetime(2024, 12, 31, calendar='standard')
 
         #: MODIS sinusoidal CRS (sphere, a=b=6 371 007.181 m).
         native_crs_out = _MODIS_SINU_CRS
@@ -322,14 +329,29 @@ class ManagerMODISEarthdata(manager_dataset.ManagerDataset):
             native_crs_out=native_crs_out,
             native_resolution=native_resolution,
             native_start=native_start,
-            native_end=native_end,
+            # native_end is variable-dependent -- see _getNativeEnd().
+            native_end=None,
             valid_variables=list(_PRODUCTS.keys()),
             default_variables=list(_PRODUCTS.keys()),
             is_temporal=True,
+            native_calendar='standard',
         )
         super().__init__(attrs)
         self.force_download = force_download
         self._session = None   # earthaccess HTTPS session, set on first use
+
+    @classmethod
+    def _productNativeEnd(cls, product_key):
+        """Return a single product's native_end: fixed date if given, else today minus its lag."""
+        info = _PRODUCTS[product_key]
+        if 'native_end' in info:
+            return info['native_end']
+        return manager_dataset.ManagerDataset._todayMinusLag(info['native_end_lag_days'],
+                                                              calendar='standard')
+
+    def _getNativeEnd(self, variables):
+        """Return the most conservative native_end across the requested products."""
+        return min(self._productNativeEnd(var) for var in variables)
 
     # ------------------------------------------------------------------
     # ManagerDataset abstract method implementations

--- a/watershed_workflow/sources/manager_ssebop.py
+++ b/watershed_workflow/sources/manager_ssebop.py
@@ -29,6 +29,25 @@ _TEMPORAL_CONFIGS = {
     'yearly':  ('annual',  lambda d: f'y{d.year}'),
 }
 
+#: Conservative publication lag (days behind "today") for the two
+#: resolutions posted on a rolling basis.  Directory listings show
+#: daily/monthly granules trailing ~50-65 days in practice.
+_NATIVE_END_LAG_DAYS = {
+    'daily': 90,
+    'monthly': 90,
+}
+
+#: Resolutions posted as a single annual batch covering the *previous*
+#: calendar year (8-day composites are bundled one zip per year; yearly is
+#: an annual product by definition).  These can never report a bound inside
+#: the current, still-incomplete year, so "today minus N days" is the wrong
+#: shape of computation -- instead, require this many days into a new year
+#: to have elapsed before trusting that the previous year has been posted.
+_NATIVE_END_YEAR_POSTING_LAG_DAYS = {
+    '8day': 150,
+    'yearly': 150,
+}
+
 #: NoData sentinel value in the raw uint16 files.
 _NODATA = 9999
 
@@ -83,9 +102,29 @@ class ManagerSSEBop(manager_dataset.ManagerDataset):
             native_crs_out=watershed_workflow.crs.from_epsg(4326),
             native_resolution=0.009652,
             native_start=cftime.datetime(2000, 1, 1, calendar='standard'),
-            native_end=cftime.datetime(2023, 12, 31, calendar='standard'),
+            # native_end is self-perpetuating -- see _getNativeEnd().
+            native_end=None,
+            native_calendar='standard',
         )
         super().__init__(attrs)
+
+    def _getNativeEnd(self, variables):
+        """Return the latest date this manager's temporal resolution can trust as published.
+
+        ``daily``/``monthly`` are posted on a rolling basis, so the bound is
+        simply today minus a publication lag.  ``8day``/``yearly`` are
+        posted as a single annual batch covering the *previous* calendar
+        year, so the bound must be Dec 31 of the most recent year that has
+        both fully elapsed and had time to be posted -- never a date inside
+        the current, still-incomplete year.
+        """
+        if self._temporal_resolution in _NATIVE_END_LAG_DAYS:
+            lag_days = _NATIVE_END_LAG_DAYS[self._temporal_resolution]
+            return manager_dataset.ManagerDataset._todayMinusLag(lag_days, calendar='standard')
+        else:
+            posting_lag_days = _NATIVE_END_YEAR_POSTING_LAG_DAYS[self._temporal_resolution]
+            cutoff = manager_dataset.ManagerDataset._todayMinusLag(posting_lag_days, calendar='standard')
+            return cftime.datetime(cutoff.year - 1, 12, 31, calendar='standard')
 
     # ------------------------------------------------------------------
     # Cache directory management

--- a/watershed_workflow/sources/test/test_manager_aorc.py
+++ b/watershed_workflow/sources/test/test_manager_aorc.py
@@ -337,7 +337,7 @@ def test_date_validation_errors(small_aorc_geometry, aorc_crs, aorc_manager):
         aorc_manager.getDataset(small_aorc_geometry, aorc_crs,
                                start='1970-01-01', end='1970-12-31', variables=['APCP_surface'])
 
-    # Test end date after AORC end (2024)
+    # Test end date after AORC end (today, minus publication lag)
     with pytest.raises(ValueError, match="End date .* is after dataset end"):
         aorc_manager.getDataset(small_aorc_geometry, aorc_crs,
-                               start='2024-01-01', end='2025-01-01', variables=['APCP_surface'])
+                               start='2024-01-01', end='2999-01-01', variables=['APCP_surface'])

--- a/watershed_workflow/sources/test/test_manager_appeears.py
+++ b/watershed_workflow/sources/test/test_manager_appeears.py
@@ -199,11 +199,19 @@ def test_date_validation_errors(modis_manager, coweeta):
             variables=['LAI']
         )
 
-    # Test end date after MODIS end (2024)
+    # Test end date after MODIS LULC end (fixed at 2024-12-31)
     with pytest.raises(ValueError, match="End date .* is after dataset end"):
         modis_manager.getDataset(
             coweeta,
             start='2020-01-01', end='2025-01-01',
+            variables=['LULC']
+        )
+
+    # Test end date after MODIS LAI end (today, minus publication lag)
+    with pytest.raises(ValueError, match="End date .* is after dataset end"):
+        modis_manager.getDataset(
+            coweeta,
+            start='2020-01-01', end='2999-01-01',
             variables=['LAI']
         )
 

--- a/watershed_workflow/sources/test/test_manager_nlcd.py
+++ b/watershed_workflow/sources/test/test_manager_nlcd.py
@@ -141,8 +141,8 @@ def test_native_properties():
     assert mgr.native_crs_in == CRS.from_epsg(4326)  # WGS84
     assert mgr.native_crs_out == CRS.from_epsg(4326) # WGS84
     assert mgr.native_resolution == 0.00027          # ~30m in degrees
-    assert mgr.native_start is None                  # Non-temporal
-    assert mgr.native_end is None                    # Non-temporal
+    assert mgr.getNativeStart() is None               # Non-temporal
+    assert mgr.getNativeEnd() is None                 # Non-temporal
     
     # Check variables
     expected_valid = ['cover', 'impervious', 'canopy', 'descriptor']

--- a/watershed_workflow/sources/test/test_manager_raster.py
+++ b/watershed_workflow/sources/test/test_manager_raster.py
@@ -37,8 +37,8 @@ def test_manager_raster_initialization(raster_manager, dtb_raster_path):
     assert raster_manager.product == 'undefined'
     assert raster_manager.source == os.path.abspath(dtb_raster_path)
     
-    assert raster_manager.native_start is None  # Non-temporal
-    assert raster_manager.native_end is None    # Non-temporal
+    assert raster_manager.getNativeStart() is None  # Non-temporal
+    assert raster_manager.getNativeEnd() is None    # Non-temporal
 
     assert raster_manager.native_crs_in is not None
     assert raster_manager.native_crs_out is not None

--- a/watershed_workflow/sources/test/test_manager_soilgrids_2017.py
+++ b/watershed_workflow/sources/test/test_manager_soilgrids_2017.py
@@ -22,8 +22,8 @@ def test_constructor(soilgrids):
     assert soilgrids.product_short == 'SoilGrids2017'
     assert soilgrids.native_crs_in == watershed_workflow.crs.from_epsg(4326)
     assert soilgrids.native_crs_out == watershed_workflow.crs.from_epsg(4326)
-    assert soilgrids.native_start is None
-    assert soilgrids.native_end is None
+    assert soilgrids.getNativeStart() is None
+    assert soilgrids.getNativeEnd() is None
     assert soilgrids.default_variables == ['BDTICM']
 
 


### PR DESCRIPTION
Managers now derive native_end dynamically (today minus a per-source publication lag, or a fixed date for annually-released products) instead of hardcoding a date that goes stale. ManagerDataset gains _getNativeStart()/_getNativeEnd() hooks so variable-dependent sources (e.g. MODIS LAI vs. LULC) can report different bounds per variable, plus an explicit calendar parameter for managers that don't supply native_start/native_end directly.

Extends the same pattern to ManagerMODISEarthdata (which wraps the same MCD15A3H/MCD12Q1 products as ManagerMODISAppEEARS, so it gets an identical variable-dependent _getNativeEnd()) and ManagerSSEBop (whose native_end was a static, stale 2023-12-31; directory listings show real publication lag varies by temporal_resolution -- daily/monthly are posted on a rolling basis, while 8day/yearly are posted as a single annual batch covering the previous calendar year and so clamp to Dec 31 of the most recent fully-elapsed, fully-posted year).

This replaces #159 with a PR based on current master.